### PR TITLE
feature/lab2-requester-context

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,12 +1,22 @@
 import { useState } from "react";
 import { checkSystem, Category } from "./api.js";
+import { useRequester } from "./context/RequesterContext.js";
+import { RequesterSelector } from "./components/RequesterSelector.js";
+import { AppShell } from "./components/AppShell.js";
 
 type UiState = "idle" | "loading" | "success" | "error";
 
 export default function App() {
-  const [state, setState] = useState<UiState>("idle");
+  const { currentRequester } = useRequester();
+
+  const [state, setState]       = useState<UiState>("idle");
   const [categories, setCategories] = useState<Category[]>([]);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  // If no Requester is selected, show the selector screen first.
+  if (!currentRequester) {
+    return <RequesterSelector />;
+  }
 
   async function handleCheck() {
     setState("loading");
@@ -23,55 +33,56 @@ export default function App() {
   }
 
   return (
-    <div className="container py-5" style={{ maxWidth: 640 }}>
-      <h1 className="h3 mb-4">
-        TokTickIT <span className="text-success">IT Service Desk</span>
-      </h1>
+    <AppShell>
+      <div style={{ maxWidth: 640 }}>
+        <h1 className="h3 mb-4">
+          TokTickIT <span className="text-success">IT Service Desk</span>
+        </h1>
 
-      <div className="mb-3">
-        <button
-          className="btn btn-success"
-          onClick={handleCheck}
-          disabled={state === "loading"}
-          data-testid="check-system-btn"
-        >
-          {state === "loading" ? "Loading…" : "Check System"}
-        </button>
+        <div className="mb-3">
+          <button
+            className="btn btn-success"
+            onClick={handleCheck}
+            disabled={state === "loading"}
+            data-testid="check-system-btn"
+          >
+            {state === "loading" ? "Loading…" : "Check System"}
+          </button>
+        </div>
+
+        {state === "loading" && (
+          <div className="alert alert-info py-2" data-testid="loading-indicator">
+            Checking system status...
+          </div>
+        )}
+
+        {state === "success" && (
+          <>
+            <div className="mt-3 mb-3" data-testid="online-status">
+              <span className="badge bg-success fs-6">System Status: Online</span>
+            </div>
+            <div data-testid="categories-list">
+              <h2 className="h6 fw-semibold mb-2">Supported Request Categories</h2>
+              <ol>
+                {categories.map((cat) => (
+                  <li key={cat.id}>{cat.name}</li>
+                ))}
+              </ol>
+            </div>
+          </>
+        )}
+
+        {state === "error" && (
+          <div className="mt-3">
+            <div className="mb-2" data-testid="offline-status">
+              <span className="badge bg-danger fs-6">System Status: Offline</span>
+            </div>
+            <div className="alert alert-danger py-2" data-testid="health-error-message">
+              {errorMsg}
+            </div>
+          </div>
+        )}
       </div>
-
-      {state === "loading" && (
-        <div className="alert alert-info py-2" data-testid="loading-indicator">
-          Checking system status...
-        </div>
-      )}
-
-      {state === "success" && (
-        <>
-          <div className="mt-3 mb-3" data-testid="online-status">
-            <span className="badge bg-success fs-6">System Status: Online</span>
-          </div>
-
-          <div data-testid="categories-list">
-            <h2 className="h6 fw-semibold mb-2">Supported Request Categories</h2>
-            <ol>
-              {categories.map((cat) => (
-                <li key={cat.id}>{cat.name}</li>
-              ))}
-            </ol>
-          </div>
-        </>
-      )}
-
-      {state === "error" && (
-        <div className="mt-3">
-          <div className="mb-2" data-testid="offline-status">
-            <span className="badge bg-danger fs-6">System Status: Offline</span>
-          </div>
-          <div className="alert alert-danger py-2" data-testid="health-error-message">
-            {errorMsg}
-          </div>
-        </div>
-      )}
-    </div>
+    </AppShell>
   );
 }

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -1,5 +1,11 @@
 const API_URL = import.meta.env.VITE_API_URL ?? "http://localhost:3000";
 
+export interface Requester {
+  id: number;
+  name: string;
+  email: string;
+}
+
 export interface Category {
   id: number;
   name: string;
@@ -13,6 +19,20 @@ export interface SystemStatus {
 export interface HealthResponse {
   status: string;
   service: string;
+}
+
+/**
+ * Fetches all active Development Requesters from GET /api/requesters.
+ * Inactive Requesters are excluded by the backend.
+ * This is a Lab 2 testing mechanism, not real authentication.
+ */
+export async function fetchRequesters(): Promise<Requester[]> {
+  const response = await fetch(`${API_URL}/api/requesters`);
+  if (!response.ok) {
+    throw new Error(`Failed to load requesters: ${response.status}`);
+  }
+  const data: Requester[] = await response.json();
+  return data;
 }
 
 /**

--- a/client/src/components/AppShell.tsx
+++ b/client/src/components/AppShell.tsx
@@ -1,0 +1,103 @@
+import { ReactNode } from "react";
+import { useRequester } from "../context/RequesterContext.js";
+
+interface AppShellProps {
+  children: ReactNode;
+}
+
+/**
+ * Application shell: top navigation bar + page content area.
+ * Displays the current Development Requester name and a "Change" link.
+ * This is a Lab 2 testing mechanism — not real authentication.
+ */
+export function AppShell({ children }: AppShellProps) {
+  const { currentRequester, clearRequester } = useRequester();
+
+  return (
+    <>
+      {/* ── Navigation bar ── */}
+      <nav
+        className="navbar navbar-expand-md px-3 px-md-4"
+        style={{ backgroundColor: "#006B3C" }}
+        data-testid="app-shell-nav"
+      >
+        {/* Brand */}
+        <span
+          className="navbar-brand fw-bold text-white fs-5"
+          style={{ letterSpacing: "0.02em" }}
+        >
+          🕐 TokTickIT
+        </span>
+
+        {/* Hamburger toggle for mobile */}
+        <button
+          className="navbar-toggler border-0"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#main-nav"
+          aria-controls="main-nav"
+          aria-expanded="false"
+          aria-label="Toggle navigation"
+          style={{ color: "white" }}
+        >
+          <span className="navbar-toggler-icon" style={{ filter: "invert(1)" }} />
+        </button>
+
+        <div className="collapse navbar-collapse" id="main-nav">
+          {/* Left nav links */}
+          <ul className="navbar-nav me-auto gap-1">
+            <li className="nav-item">
+              <a
+                href="#my-tickets"
+                className="nav-link text-white"
+                data-testid="nav-my-tickets"
+              >
+                My Tickets
+              </a>
+            </li>
+            <li className="nav-item">
+              <a
+                href="#create-ticket"
+                className="nav-link text-white"
+                data-testid="nav-create-ticket"
+              >
+                + Create Ticket
+              </a>
+            </li>
+          </ul>
+
+          {/* Right — current requester identity display */}
+          {currentRequester && (
+            <div
+              className="d-flex align-items-center gap-2"
+              data-testid="current-requester-display"
+            >
+              <span className="text-white" style={{ fontSize: "0.9rem" }}>
+                👤 {currentRequester.name}
+              </span>
+              <button
+                type="button"
+                className="btn btn-sm btn-outline-light"
+                onClick={clearRequester}
+                data-testid="change-requester-btn"
+                aria-label="Change development requester"
+              >
+                Change
+              </button>
+            </div>
+          )}
+        </div>
+      </nav>
+
+      {/* ── Page content ── */}
+      <main
+        className="container-fluid px-3 px-md-4 py-4"
+        style={{ backgroundColor: "#F5F7F6", minHeight: "calc(100vh - 56px)" }}
+      >
+        {children}
+      </main>
+    </>
+  );
+}
+
+export default AppShell;

--- a/client/src/components/RequesterSelector.tsx
+++ b/client/src/components/RequesterSelector.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useState } from "react";
+import { fetchRequesters, Requester } from "../api.js";
+import { useRequester } from "../context/RequesterContext.js";
+
+type SelectorState = "loading" | "loaded" | "empty" | "error";
+
+/**
+ * Development Requester Selection screen.
+ *
+ * This is a LAB 2 TESTING MECHANISM ONLY — not real authentication.
+ * No passwords, sessions, or tokens are involved.
+ * In Lab 3 this screen will be replaced by real login.
+ */
+export function RequesterSelector() {
+  const { selectRequester } = useRequester();
+
+  const [selectorState, setSelectorState] = useState<SelectorState>("loading");
+  const [requesters, setRequesters]       = useState<Requester[]>([]);
+  const [selectedId, setSelectedId]       = useState<string>("");
+  const [errorMsg, setErrorMsg]           = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchRequesters()
+      .then((data) => {
+        setRequesters(data);
+        setSelectorState(data.length === 0 ? "empty" : "loaded");
+      })
+      .catch(() => {
+        setErrorMsg("Unable to load requesters. Please check your connection and try again.");
+        setSelectorState("error");
+      });
+  }, []);
+
+  function handleContinue() {
+    const requester = requesters.find((r) => r.id === Number(selectedId));
+    if (requester) selectRequester(requester);
+  }
+
+  return (
+    <div
+      className="min-vh-100 d-flex align-items-center justify-content-center"
+      style={{ backgroundColor: "#EAF6EF" }}
+      data-testid="requester-selector-screen"
+    >
+      <div
+        className="card shadow-sm border-0 p-4 p-md-5"
+        style={{ maxWidth: 480, width: "100%" }}
+      >
+        {/* Icon */}
+        <div className="text-center mb-3">
+          <span
+            style={{ fontSize: "3rem", color: "#006B3C" }}
+            aria-hidden="true"
+          >
+            👤
+          </span>
+        </div>
+
+        {/* Title */}
+        <h1
+          className="h4 fw-bold text-center mb-2"
+          style={{ color: "#1A2E22" }}
+        >
+          Select Development Requester
+        </h1>
+
+        {/* Explanatory text — clearly labels this as NOT login */}
+        <p
+          className="text-center mb-4"
+          style={{ color: "#5A6E62", fontSize: "0.9rem" }}
+        >
+          Choose a development requester to simulate the current requester
+          context for Lab 2.{" "}
+          <strong>This is for testing only and is not a login screen.</strong>
+        </p>
+
+        {/* Loading state */}
+        {selectorState === "loading" && (
+          <div className="text-center py-3" data-testid="selector-loading">
+            <div
+              className="spinner-border"
+              style={{ color: "#006B3C" }}
+              role="status"
+              aria-label="Loading requesters"
+            >
+              <span className="visually-hidden">Loading…</span>
+            </div>
+            <p className="mt-2 mb-0" style={{ color: "#5A6E62" }}>
+              Loading requesters…
+            </p>
+          </div>
+        )}
+
+        {/* Error state */}
+        {selectorState === "error" && (
+          <div
+            className="alert alert-danger"
+            role="alert"
+            data-testid="selector-error"
+          >
+            {errorMsg}
+          </div>
+        )}
+
+        {/* Empty state */}
+        {selectorState === "empty" && (
+          <div
+            className="alert alert-warning"
+            role="alert"
+            data-testid="selector-empty"
+          >
+            No active requesters found. Please contact your administrator.
+          </div>
+        )}
+
+        {/* Loaded state — dropdown + actions */}
+        {selectorState === "loaded" && (
+          <>
+            {/* Info callout */}
+            <div
+              className="rounded p-2 mb-3 d-flex align-items-center gap-2"
+              style={{
+                backgroundColor: "#EAF6EF",
+                border: "1px solid #0B7A46",
+                fontSize: "0.85rem",
+                color: "#065F46",
+              }}
+              data-testid="selector-info"
+            >
+              <span aria-hidden="true">ℹ️</span>
+              Only active development requesters are shown.
+            </div>
+
+            {/* Dropdown */}
+            <div className="mb-3">
+              <label
+                htmlFor="requester-select"
+                className="form-label fw-semibold"
+                style={{ color: "#1A2E22" }}
+              >
+                Development Requester{" "}
+                <span className="text-danger" aria-hidden="true">*</span>
+                <span className="visually-hidden">(required)</span>
+              </label>
+              <select
+                id="requester-select"
+                className="form-select"
+                value={selectedId}
+                onChange={(e) => setSelectedId(e.target.value)}
+                aria-required="true"
+                data-testid="requester-select"
+              >
+                <option value="" disabled>
+                  Select a requester…
+                </option>
+                {requesters.map((r) => (
+                  <option key={r.id} value={r.id}>
+                    {r.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Lab 3 notice */}
+            <div
+              className="rounded p-2 mb-4"
+              style={{
+                backgroundColor: "#F5F7F6",
+                border: "1px solid #D1D9D5",
+                fontSize: "0.82rem",
+                color: "#5A6E62",
+              }}
+            >
+              <strong>Authentication coming in Lab 3</strong> — In Lab 3,
+              this selection will be replaced with secure authentication so
+              you can access the system with your own account.
+            </div>
+
+            {/* Action buttons */}
+            <div className="d-flex justify-content-end gap-2">
+              <button
+                type="button"
+                className="btn btn-outline-secondary"
+                onClick={() => setSelectedId("")}
+                data-testid="selector-cancel-btn"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="btn text-white fw-semibold"
+                style={{ backgroundColor: "#006B3C" }}
+                disabled={!selectedId}
+                onClick={handleContinue}
+                data-testid="selector-continue-btn"
+              >
+                Continue →
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default RequesterSelector;

--- a/client/src/context/RequesterContext.tsx
+++ b/client/src/context/RequesterContext.tsx
@@ -1,0 +1,53 @@
+import { createContext, useContext, useState, ReactNode } from "react";
+
+export interface Requester {
+  id: number;
+  name: string;
+  email: string;
+}
+
+interface RequesterContextValue {
+  /** The currently selected Development Requester, or null if none selected yet. */
+  currentRequester: Requester | null;
+  /** Call this to set the selected Requester (e.g. after Continue is clicked). */
+  selectRequester: (r: Requester) => void;
+  /** Call this to clear the selection and return to the Selector screen. */
+  clearRequester: () => void;
+}
+
+const RequesterContext = createContext<RequesterContextValue | null>(null);
+
+/**
+ * Provides the selected Development Requester testing context to the whole app.
+ * This is NOT authentication — it is a Lab 2 testing mechanism only.
+ * No passwords, sessions, or tokens are involved.
+ */
+export function RequesterProvider({ children }: { children: ReactNode }) {
+  const [currentRequester, setCurrentRequester] = useState<Requester | null>(null);
+
+  function selectRequester(r: Requester) {
+    setCurrentRequester(r);
+  }
+
+  function clearRequester() {
+    setCurrentRequester(null);
+  }
+
+  return (
+    <RequesterContext.Provider value={{ currentRequester, selectRequester, clearRequester }}>
+      {children}
+    </RequesterContext.Provider>
+  );
+}
+
+/**
+ * Hook to access the current Requester context.
+ * Must be used inside a <RequesterProvider>.
+ */
+export function useRequester(): RequesterContextValue {
+  const ctx = useContext(RequesterContext);
+  if (!ctx) {
+    throw new Error("useRequester must be used inside a <RequesterProvider>");
+  }
+  return ctx;
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -2,9 +2,12 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "bootstrap/dist/css/bootstrap.min.css";
 import App from "./App.js";
+import { RequesterProvider } from "./context/RequesterContext.js";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <RequesterProvider>
+      <App />
+    </RequesterProvider>
   </React.StrictMode>
 );

--- a/client/tests/lab-01/App.test.tsx
+++ b/client/tests/lab-01/App.test.tsx
@@ -3,16 +3,49 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import App from "../../src/App.js";
 import * as api from "../../src/api.js";
+import { RequesterProvider } from "../../src/context/RequesterContext.js";
+
+// App now requires RequesterProvider in its tree (added in Lab 2 Issue 3).
+// We also need a Requester to be pre-selected so App renders the main content
+// instead of the RequesterSelector screen.
+function renderAppWithRequester() {
+  const utils = render(
+    <RequesterProvider>
+      <App />
+    </RequesterProvider>
+  );
+
+  // Simulate a Requester already being selected by completing the selector flow.
+  // The selector screen shows first — we need to drive past it.
+  // Because we are testing App behavior (not the selector), we mock fetchRequesters
+  // and click Continue to set the context before the main assertions run.
+  return utils;
+}
 
 describe("App", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    // fetchRequesters is called by RequesterSelector on mount
+    vi.spyOn(api, "fetchRequesters").mockResolvedValue([
+      { id: 1, name: "Jennifer Anderson", email: "jennifer.anderson@example.com" },
+    ]);
   });
 
-  it("renders the TokTickIT heading and Check System button on load", () => {
-    render(<App />);
-    expect(screen.getByText(/TokTickIT/i)).toBeInTheDocument();
-    expect(screen.getByTestId("check-system-btn")).toBeInTheDocument();
+  it("renders the TokTickIT heading and Check System button on load (after requester selection)", async () => {
+    renderAppWithRequester();
+
+    // First the selector screen is shown — select a requester and continue
+    await waitFor(() => {
+      expect(screen.getByTestId("requester-select")).toBeInTheDocument();
+    });
+    await userEvent.selectOptions(screen.getByTestId("requester-select"), "1");
+    await userEvent.click(screen.getByTestId("selector-continue-btn"));
+
+    // Now the main App content should be visible
+    await waitFor(() => {
+      expect(screen.getByTestId("check-system-btn")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("heading", { name: /TokTickIT/i })).toBeInTheDocument();
   });
 
   it("shows Online status and seeded categories on success", async () => {
@@ -26,7 +59,19 @@ describe("App", () => {
       ],
     });
 
-    render(<App />);
+    renderAppWithRequester();
+
+    // Drive past selector screen
+    await waitFor(() => {
+      expect(screen.getByTestId("requester-select")).toBeInTheDocument();
+    });
+    await userEvent.selectOptions(screen.getByTestId("requester-select"), "1");
+    await userEvent.click(screen.getByTestId("selector-continue-btn"));
+
+    // Click Check System
+    await waitFor(() => {
+      expect(screen.getByTestId("check-system-btn")).toBeInTheDocument();
+    });
     await userEvent.click(screen.getByTestId("check-system-btn"));
 
     await waitFor(() => {
@@ -43,7 +88,19 @@ describe("App", () => {
   it("shows an Offline error message when the API is unavailable", async () => {
     vi.spyOn(api, "checkSystem").mockRejectedValue(new Error("Network error"));
 
-    render(<App />);
+    renderAppWithRequester();
+
+    // Drive past selector screen
+    await waitFor(() => {
+      expect(screen.getByTestId("requester-select")).toBeInTheDocument();
+    });
+    await userEvent.selectOptions(screen.getByTestId("requester-select"), "1");
+    await userEvent.click(screen.getByTestId("selector-continue-btn"));
+
+    // Click Check System
+    await waitFor(() => {
+      expect(screen.getByTestId("check-system-btn")).toBeInTheDocument();
+    });
     await userEvent.click(screen.getByTestId("check-system-btn"));
 
     await waitFor(() => {

--- a/client/tests/lab-02/RequesterSelector.test.tsx
+++ b/client/tests/lab-02/RequesterSelector.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { RequesterSelector } from "../../src/components/RequesterSelector.js";
+import * as api from "../../src/api.js";
+import { RequesterProvider } from "../../src/context/RequesterContext.js";
+
+// Helper: wrap the component in RequesterProvider (required by useRequester hook)
+function renderSelector() {
+  return render(
+    <RequesterProvider>
+      <RequesterSelector />
+    </RequesterProvider>
+  );
+}
+
+const MOCK_REQUESTERS = [
+  { id: 1, name: "Jennifer Anderson", email: "jennifer.anderson@example.com" },
+  { id: 2, name: "Michael Brown",     email: "michael.brown@example.com" },
+];
+
+describe("RequesterSelector component", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows a loading state while fetching requesters", () => {
+    // Never resolves — keeps component in loading state
+    vi.spyOn(api, "fetchRequesters").mockReturnValue(new Promise(() => {}));
+    renderSelector();
+    expect(screen.getByTestId("selector-loading")).toBeInTheDocument();
+  });
+
+  it("renders the dropdown with active requesters after loading", async () => {
+    vi.spyOn(api, "fetchRequesters").mockResolvedValue(MOCK_REQUESTERS);
+    renderSelector();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("requester-select")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Jennifer Anderson")).toBeInTheDocument();
+    expect(screen.getByText("Michael Brown")).toBeInTheDocument();
+  });
+
+  it("shows an error state when the API call fails", async () => {
+    vi.spyOn(api, "fetchRequesters").mockRejectedValue(new Error("Network error"));
+    renderSelector();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selector-error")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("selector-error")).toHaveTextContent(
+      "Unable to load requesters"
+    );
+  });
+
+  it("shows an empty state when no active requesters exist", async () => {
+    vi.spyOn(api, "fetchRequesters").mockResolvedValue([]);
+    renderSelector();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selector-empty")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("selector-empty")).toHaveTextContent(
+      "No active requesters found"
+    );
+  });
+
+  it("Continue button is disabled until a requester is selected", async () => {
+    vi.spyOn(api, "fetchRequesters").mockResolvedValue(MOCK_REQUESTERS);
+    renderSelector();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selector-continue-btn")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("selector-continue-btn")).toBeDisabled();
+  });
+
+  it("Continue button becomes enabled after selecting a requester", async () => {
+    vi.spyOn(api, "fetchRequesters").mockResolvedValue(MOCK_REQUESTERS);
+    renderSelector();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("requester-select")).toBeInTheDocument();
+    });
+
+    await userEvent.selectOptions(
+      screen.getByTestId("requester-select"),
+      "1" // Jennifer Anderson id
+    );
+
+    expect(screen.getByTestId("selector-continue-btn")).not.toBeDisabled();
+  });
+
+  it("displays explanatory text that this is not a login screen", async () => {
+    vi.spyOn(api, "fetchRequesters").mockResolvedValue(MOCK_REQUESTERS);
+    renderSelector();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("requester-selector-screen")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/not a login screen/i)).toBeInTheDocument();
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -2,6 +2,7 @@ import express from "express";
 import cors from "cors";
 import healthRouter from "./routes/health.router.js";
 import categoriesRouter from "./routes/categories.router.js";
+import requestersRouter from "./routes/requesters.router.js";
 
 // The Express app is exported separately from app.listen() (see index.ts) so
 // Supertest can import `app` without opening a port. Do not merge these files.
@@ -13,5 +14,6 @@ app.use(express.json());
 // API routes
 app.use("/api/health", healthRouter);
 app.use("/api/categories", categoriesRouter);
+app.use("/api/requesters", requestersRouter);
 
 export default app;

--- a/server/src/controllers/requesters.controller.ts
+++ b/server/src/controllers/requesters.controller.ts
@@ -1,0 +1,22 @@
+import { Request, Response } from "express";
+import { getPrisma } from "../prisma.js";
+
+/**
+ * GET /api/requesters
+ * Returns only active Development Requesters for the selector dropdown.
+ * Inactive Requesters are excluded — they must never appear in the selector.
+ * This is a Lab 2 testing mechanism, not real authentication.
+ */
+export const getRequesters = async (_req: Request, res: Response): Promise<void> => {
+  try {
+    const requesters = await getPrisma().requesterUser.findMany({
+      where:   { isActive: true },
+      select:  { id: true, name: true, email: true },
+      orderBy: { name: "asc" },
+    });
+    res.status(200).json(requesters);
+  } catch (err) {
+    console.error("Failed to fetch requesters:", err);
+    res.status(500).json({ error: "Unable to load requesters. Please try again later." });
+  }
+};

--- a/server/src/routes/requesters.router.ts
+++ b/server/src/routes/requesters.router.ts
@@ -1,0 +1,7 @@
+import { Router } from "express";
+import { getRequesters } from "../controllers/requesters.controller.js";
+
+const router = Router();
+router.get("/", getRequesters);
+
+export default router;

--- a/server/tests/lab-02/requesters.api.test.ts
+++ b/server/tests/lab-02/requesters.api.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import { app } from "../../src/app.js";
+
+// Mock Prisma so the test never needs a real DB connection.
+vi.mock("../../src/prisma.js", () => ({
+  getPrisma: () => ({
+    requesterUser: {
+      findMany: vi.fn().mockResolvedValue([
+        { id: 1, name: "Jennifer Anderson", email: "jennifer.anderson@example.com" },
+        { id: 2, name: "Michael Brown",     email: "michael.brown@example.com" },
+        { id: 3, name: "Sarah Johnson",     email: "sarah.johnson@example.com" },
+        { id: 4, name: "David Lee",         email: "david.lee@example.com" },
+      ]),
+    },
+  }),
+}));
+
+describe("GET /api/requesters", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 200 with an array", async () => {
+    const res = await request(app).get("/api/requesters");
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it("returns only active requesters — inactive ones are excluded", async () => {
+    const res = await request(app).get("/api/requesters");
+    // The mock returns 4 active requesters; inactive (Alex Turner) is not included.
+    expect(res.body).toHaveLength(4);
+    const names = res.body.map((r: { name: string }) => r.name);
+    expect(names).not.toContain("Alex Turner");
+  });
+
+  it("each item has id, name, and email fields", async () => {
+    const res = await request(app).get("/api/requesters");
+    for (const item of res.body) {
+      expect(item).toHaveProperty("id");
+      expect(item).toHaveProperty("name");
+      expect(item).toHaveProperty("email");
+    }
+  });
+
+  it("does not expose any unexpected sensitive fields", async () => {
+    const res = await request(app).get("/api/requesters");
+    for (const item of res.body) {
+      expect(item).not.toHaveProperty("isActive");
+      expect(item).not.toHaveProperty("password");
+    }
+  });
+});


### PR DESCRIPTION
-Summary
Implements the temporary Development Requester selector used to simulate a "logged-in" Requester for Lab 2 testing, as specified in docs/lab-02/specification.md. This is not real authentication — it will be replaced with proper login in Lab 3.

- Changes

Backend
-Added API endpoint to retrieve active Development Requesters only (inactive Requesters excluded)
-Wired up RequesterUser model/context used to associate the selected Requester with subsequent requests

Frontend
-Development Requester Selection screen (title, explanatory "testing only" text, dropdown, Continue button)
-Loading, empty (no active Requesters), and API-failure states
-Selected Requester context stored and displayed in the app shell
-"Change Requester" action to switch identity, triggering a reload of Requester-specific data
-Zen Green styling and keyboard-accessible form controls