### PR TITLE
feature/lab2-create-ticket

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,15 +3,18 @@ import { checkSystem, Category } from "./api.js";
 import { useRequester } from "./context/RequesterContext.js";
 import { RequesterSelector } from "./components/RequesterSelector.js";
 import { AppShell } from "./components/AppShell.js";
+import { CreateTicket } from "./components/CreateTicket.js";
 
+type Page = "home" | "create-ticket";
 type UiState = "idle" | "loading" | "success" | "error";
 
 export default function App() {
   const { currentRequester } = useRequester();
 
-  const [state, setState]       = useState<UiState>("idle");
+  const [page,       setPage]       = useState<Page>("home");
+  const [state,      setState]      = useState<UiState>("idle");
   const [categories, setCategories] = useState<Category[]>([]);
-  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [errorMsg,   setErrorMsg]   = useState<string | null>(null);
 
   // If no Requester is selected, show the selector screen first.
   if (!currentRequester) {
@@ -32,8 +35,20 @@ export default function App() {
     }
   }
 
+  // ── Create Ticket page ────────────────────────────────────────────────
+
+  if (page === "create-ticket") {
+    return (
+      <AppShell activePage="create-ticket" onNavigate={setPage}>
+        <CreateTicket onCancel={() => setPage("home")} />
+      </AppShell>
+    );
+  }
+
+  // ── Home page ─────────────────────────────────────────────────────────
+
   return (
-    <AppShell>
+    <AppShell activePage="home" onNavigate={setPage}>
       <div style={{ maxWidth: 640 }}>
         <h1 className="h3 mb-4">
           TokTickIT <span className="text-success">IT Service Desk</span>

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -11,6 +11,50 @@ export interface Category {
   name: string;
 }
 
+export interface RelatedSystem {
+  id: number;
+  name: string;
+}
+
+export type Priority = "LOW" | "MEDIUM" | "HIGH";
+
+export interface Ticket {
+  id: number;
+  ticketNumber: string;
+  requesterId: number;
+  categoryId: number;
+  relatedSystemId: number;
+  summary: string;
+  description: string;
+  requestedPriority: Priority;
+  status: string;
+  ticketDate: string;
+  createdAt: string;
+  updatedAt: string;
+  requester?:     { id: number; name: string };
+  category?:      { id: number; name: string };
+  relatedSystem?: { id: number; name: string };
+}
+
+export interface CreateTicketPayload {
+  requesterId:       number;
+  categoryId:        number;
+  relatedSystemId:   number;
+  summary:           string;
+  description:       string;
+  requestedPriority: Priority;
+}
+
+export interface AttachmentMeta {
+  id:            number;
+  originalName:  string;
+  mimeType:      string;
+  sizeBytes:     number;
+  uploadedAt:    string;
+  removedAt:     string | null;
+  removalReason: string | null;
+}
+
 export interface SystemStatus {
   online: boolean;
   categories: Category[];
@@ -21,6 +65,8 @@ export interface HealthResponse {
   service: string;
 }
 
+// ── Requester ──────────────────────────────────────────────────────────────
+
 /**
  * Fetches all active Development Requesters from GET /api/requesters.
  * Inactive Requesters are excluded by the backend.
@@ -28,49 +74,89 @@ export interface HealthResponse {
  */
 export async function fetchRequesters(): Promise<Requester[]> {
   const response = await fetch(`${API_URL}/api/requesters`);
-  if (!response.ok) {
-    throw new Error(`Failed to load requesters: ${response.status}`);
-  }
-  const data: Requester[] = await response.json();
-  return data;
+  if (!response.ok) throw new Error(`Failed to load requesters: ${response.status}`);
+  return response.json();
 }
 
-/**
- * Sends a GET request to /api/health to check the backend service status.
- */
-export async function fetchHealth(): Promise<HealthResponse> {
-  const response = await fetch(`${API_URL}/api/health`);
-  if (!response.ok) {
-    throw new Error(`Backend unavailable with status ${response.status}`);
-  }
-  const data: HealthResponse = await response.json();
-  return data;
-}
+// ── Reference data ─────────────────────────────────────────────────────────
 
 /**
- * Fetches all categories from GET /api/categories.
- * Returns them in the order the API provides (name asc).
+ * Fetches all active Categories from GET /api/categories.
  */
 export async function fetchCategories(): Promise<Category[]> {
   const response = await fetch(`${API_URL}/api/categories`);
-  if (!response.ok) {
-    throw new Error(`Failed to load categories: ${response.status}`);
-  }
-  const data: Category[] = await response.json();
-  return data;
+  if (!response.ok) throw new Error(`Failed to load categories: ${response.status}`);
+  return response.json();
 }
 
-// Issue 2 + Issue 4 — call the backend.
+/**
+ * Fetches all active Related Systems from GET /api/related-systems.
+ */
+export async function fetchRelatedSystems(): Promise<RelatedSystem[]> {
+  const response = await fetch(`${API_URL}/api/related-systems`);
+  if (!response.ok) throw new Error(`Failed to load related systems: ${response.status}`);
+  return response.json();
+}
+
+// ── Health ─────────────────────────────────────────────────────────────────
+
+export async function fetchHealth(): Promise<HealthResponse> {
+  const response = await fetch(`${API_URL}/api/health`);
+  if (!response.ok) throw new Error(`Backend unavailable with status ${response.status}`);
+  return response.json();
+}
+
 export async function checkSystem(): Promise<SystemStatus> {
-  const [health, categories] = await Promise.all([
-    fetchHealth(),
-    fetchCategories(),
-  ]);
+  const [health, categories] = await Promise.all([fetchHealth(), fetchCategories()]);
   if (health.status !== "online" && health.status !== "ok") {
     throw new Error("Backend system is not online");
   }
-  return {
-    online: true,
-    categories,
-  };
+  return { online: true, categories };
+}
+
+// ── Tickets ────────────────────────────────────────────────────────────────
+
+/**
+ * POST /api/tickets — creates a new ticket for the selected Requester.
+ * Throws with parsed field errors on 400 validation failure.
+ */
+export async function createTicket(payload: CreateTicketPayload): Promise<Ticket> {
+  const response = await fetch(`${API_URL}/api/tickets`, {
+    method:  "POST",
+    headers: { "Content-Type": "application/json" },
+    body:    JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}));
+    const msg  = body?.error?.message ?? `Failed to create ticket: ${response.status}`;
+    const err  = Object.assign(new Error(msg), { fields: body?.error?.fields ?? {} });
+    throw err;
+  }
+  return response.json();
+}
+
+// ── Attachments ────────────────────────────────────────────────────────────
+
+/**
+ * POST /api/tickets/:ticketNumber/attachments — uploads one file.
+ * Returns attachment metadata on success.
+ */
+export async function uploadAttachment(
+  ticketNumber: string,
+  requesterId: number,
+  file: File
+): Promise<AttachmentMeta> {
+  const formData = new FormData();
+  formData.append("requesterId", String(requesterId));
+  formData.append("file", file);
+
+  const response = await fetch(
+    `${API_URL}/api/tickets/${ticketNumber}/attachments`,
+    { method: "POST", body: formData }
+  );
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}));
+    throw new Error(body?.error?.message ?? `Upload failed: ${response.status}`);
+  }
+  return response.json();
 }

--- a/client/src/components/AppShell.tsx
+++ b/client/src/components/AppShell.tsx
@@ -1,8 +1,12 @@
 import { ReactNode } from "react";
 import { useRequester } from "../context/RequesterContext.js";
 
+type Page = "home" | "create-ticket";
+
 interface AppShellProps {
-  children: ReactNode;
+  children:    ReactNode;
+  activePage?: Page;
+  onNavigate?: (page: Page) => void;
 }
 
 /**
@@ -10,8 +14,14 @@ interface AppShellProps {
  * Displays the current Development Requester name and a "Change" link.
  * This is a Lab 2 testing mechanism — not real authentication.
  */
-export function AppShell({ children }: AppShellProps) {
+export function AppShell({ children, activePage, onNavigate }: AppShellProps) {
   const { currentRequester, clearRequester } = useRequester();
+
+  function navLinkStyle(page: Page): React.CSSProperties {
+    return activePage === page
+      ? { borderBottom: "2px solid #EAF6EF", paddingBottom: 2 }
+      : {};
+  }
 
   return (
     <>
@@ -22,12 +32,14 @@ export function AppShell({ children }: AppShellProps) {
         data-testid="app-shell-nav"
       >
         {/* Brand */}
-        <span
-          className="navbar-brand fw-bold text-white fs-5"
-          style={{ letterSpacing: "0.02em" }}
+        <button
+          className="navbar-brand fw-bold text-white fs-5 btn p-0 border-0"
+          style={{ letterSpacing: "0.02em", background: "none" }}
+          onClick={() => onNavigate?.("home")}
+          aria-label="TokTickIT home"
         >
           🕐 TokTickIT
-        </span>
+        </button>
 
         {/* Hamburger toggle for mobile */}
         <button
@@ -47,22 +59,26 @@ export function AppShell({ children }: AppShellProps) {
           {/* Left nav links */}
           <ul className="navbar-nav me-auto gap-1">
             <li className="nav-item">
-              <a
-                href="#my-tickets"
-                className="nav-link text-white"
+              <button
+                className="nav-link text-white btn p-2 border-0"
+                style={navLinkStyle("home")}
+                onClick={() => onNavigate?.("home")}
                 data-testid="nav-my-tickets"
+                aria-current={activePage === "home" ? "page" : undefined}
               >
                 My Tickets
-              </a>
+              </button>
             </li>
             <li className="nav-item">
-              <a
-                href="#create-ticket"
-                className="nav-link text-white"
+              <button
+                className="nav-link text-white btn p-2 border-0"
+                style={navLinkStyle("create-ticket")}
+                onClick={() => onNavigate?.("create-ticket")}
                 data-testid="nav-create-ticket"
+                aria-current={activePage === "create-ticket" ? "page" : undefined}
               >
                 + Create Ticket
-              </a>
+              </button>
             </li>
           </ul>
 

--- a/client/src/components/CreateTicket.tsx
+++ b/client/src/components/CreateTicket.tsx
@@ -1,0 +1,545 @@
+import { useEffect, useState, useRef, ChangeEvent } from "react";
+import {
+  fetchCategories,
+  fetchRelatedSystems,
+  createTicket,
+  uploadAttachment,
+  Category,
+  RelatedSystem,
+  Priority,
+} from "../api.js";
+import { useRequester } from "../context/RequesterContext.js";
+
+// ── Constants ────────────────────────────────────────────────────────────
+
+const ALLOWED_TYPES  = ["image/jpeg", "image/jpg", "image/png", "image/webp", "application/pdf"];
+const MAX_SIZE_BYTES = 5 * 1024 * 1024;
+const MAX_FILES      = 5;
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+interface FieldErrors {
+  summary?:           string;
+  description?:       string;
+  categoryId?:        string;
+  relatedSystemId?:   string;
+  requestedPriority?: string;
+  [key: string]: string | undefined;
+}
+
+interface PendingFile {
+  file:  File;
+  error: string | null;
+}
+
+type FormState = "idle" | "submitting" | "success" | "error";
+
+// ── Component ────────────────────────────────────────────────────────────
+
+interface CreateTicketProps {
+  onCancel?: () => void;
+}
+
+export function CreateTicket({ onCancel }: CreateTicketProps) {
+  const { currentRequester } = useRequester();
+
+  // Reference data
+  const [categories,     setCategories]     = useState<Category[]>([]);
+  const [relatedSystems, setRelatedSystems] = useState<RelatedSystem[]>([]);
+  const [refLoading,     setRefLoading]     = useState(true);
+  const [refError,       setRefError]       = useState<string | null>(null);
+
+  // Form fields
+  const [summary,           setSummary]           = useState("");
+  const [description,       setDescription]       = useState("");
+  const [categoryId,        setCategoryId]        = useState("");
+  const [relatedSystemId,   setRelatedSystemId]   = useState("");
+  const [requestedPriority, setRequestedPriority] = useState<Priority | "">("");
+  const [pendingFiles,      setPendingFiles]       = useState<PendingFile[]>([]);
+
+  // Form state
+  const [formState,   setFormState]   = useState<FormState>("idle");
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [apiError,    setApiError]    = useState<string | null>(null);
+  const [successTicketNumber, setSuccessTicketNumber] = useState<string | null>(null);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Load reference data on mount
+  useEffect(() => {
+    Promise.all([fetchCategories(), fetchRelatedSystems()])
+      .then(([cats, systems]) => {
+        setCategories(cats);
+        setRelatedSystems(systems);
+        setRefLoading(false);
+      })
+      .catch(() => {
+        setRefError("Unable to load form data. Please refresh and try again.");
+        setRefLoading(false);
+      });
+  }, []);
+
+  // ── Client-side validation ─────────────────────────────────────────────
+
+  function validate(): FieldErrors {
+    const errors: FieldErrors = {};
+    if (!summary.trim())               errors.summary           = "Summary is required.";
+    else if (summary.trim().length < 5)  errors.summary         = "Summary must be at least 5 characters.";
+    else if (summary.trim().length > 150) errors.summary        = "Summary must be 150 characters or fewer.";
+    if (!description.trim())           errors.description       = "Description is required.";
+    else if (description.trim().length < 10) errors.description = "Description must be at least 10 characters.";
+    else if (description.trim().length > 2000) errors.description = "Description must be 2000 characters or fewer.";
+    if (!categoryId)                   errors.categoryId        = "Category is required.";
+    if (!relatedSystemId)              errors.relatedSystemId   = "Related System is required.";
+    if (!requestedPriority)            errors.requestedPriority = "Requested Priority is required.";
+    return errors;
+  }
+
+  // ── File handling ──────────────────────────────────────────────────────
+
+  function handleFileChange(e: ChangeEvent<HTMLInputElement>) {
+    const files = Array.from(e.target.files ?? []);
+    const newPending: PendingFile[] = files.map((file) => {
+      if (!ALLOWED_TYPES.includes(file.type)) {
+        return { file, error: `"${file.name}" is not an allowed file type (JPG, PNG, WEBP, PDF only).` };
+      }
+      if (file.size > MAX_SIZE_BYTES) {
+        return { file, error: `"${file.name}" exceeds the 5 MB size limit.` };
+      }
+      return { file, error: null };
+    });
+
+    setPendingFiles((prev) => {
+      const combined = [...prev, ...newPending];
+      // Keep at most MAX_FILES valid files + all invalid ones for error display
+      return combined;
+    });
+    // Reset input so the same file can be re-selected after removal
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  }
+
+  function removePendingFile(index: number) {
+    setPendingFiles((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  // ── Submit ─────────────────────────────────────────────────────────────
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!currentRequester) return;
+
+    const errors = validate();
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      return;
+    }
+    setFieldErrors({});
+
+    const validFiles  = pendingFiles.filter((f) => !f.error);
+    const invalidCount = pendingFiles.filter((f) => f.error).length;
+    if (invalidCount > 0) {
+      setApiError("Please remove invalid files before submitting.");
+      return;
+    }
+    if (validFiles.length > MAX_FILES) {
+      setApiError(`You can attach at most ${MAX_FILES} files per ticket.`);
+      return;
+    }
+
+    setFormState("submitting");
+    setApiError(null);
+
+    try {
+      // 1. Create the ticket
+      const ticket = await createTicket({
+        requesterId:       currentRequester.id,
+        categoryId:        Number(categoryId),
+        relatedSystemId:   Number(relatedSystemId),
+        summary:           summary.trim(),
+        description:       description.trim(),
+        requestedPriority: requestedPriority as Priority,
+      });
+
+      // 2. Upload attachments one by one (ticket is NOT rolled back on upload failure)
+      const uploadErrors: string[] = [];
+      for (const { file } of validFiles) {
+        try {
+          await uploadAttachment(ticket.ticketNumber, currentRequester.id, file);
+        } catch (err) {
+          uploadErrors.push(
+            `"${file.name}" could not be uploaded: ${err instanceof Error ? err.message : "unknown error"}`
+          );
+        }
+      }
+
+      setSuccessTicketNumber(ticket.ticketNumber);
+      setFormState("success");
+
+      if (uploadErrors.length > 0) {
+        setApiError(
+          `Ticket created, but some attachments failed to upload:\n${uploadErrors.join("\n")}`
+        );
+      }
+    } catch (err: unknown) {
+      // Server-side field validation errors
+      const fieldErrs = (err as { fields?: FieldErrors }).fields;
+      if (fieldErrs && Object.keys(fieldErrs).length > 0) {
+        setFieldErrors(fieldErrs);
+        setFormState("idle");
+      } else {
+        setApiError(
+          err instanceof Error
+            ? err.message
+            : "Unable to create ticket. Please try again later."
+        );
+        setFormState("error");
+      }
+      // Form values are preserved (no reset) so the user doesn't lose their work
+    }
+  }
+
+  // ── Render helpers ─────────────────────────────────────────────────────
+
+  function FieldError({ name }: { name: string }) {
+    const msg = fieldErrors[name];
+    if (!msg) return null;
+    return (
+      <div
+        className="text-danger mt-1"
+        style={{ fontSize: "0.82rem" }}
+        role="alert"
+        data-testid={`error-${name}`}
+      >
+        {msg}
+      </div>
+    );
+  }
+
+  const isSubmitting = formState === "submitting";
+  const labelStyle   = { color: "#1A2E22", fontWeight: 600, fontSize: "0.875rem" };
+  const inputClass   = "form-control";
+  const readonlyClass = "form-control-plaintext ps-2";
+
+  // ── Loading / error reference data ────────────────────────────────────
+
+  if (refLoading) {
+    return (
+      <div className="text-center py-5" data-testid="create-ticket-ref-loading">
+        <div className="spinner-border" style={{ color: "#006B3C" }} role="status">
+          <span className="visually-hidden">Loading form data…</span>
+        </div>
+        <p className="mt-2" style={{ color: "#5A6E62" }}>Loading form data…</p>
+      </div>
+    );
+  }
+
+  if (refError) {
+    return (
+      <div className="alert alert-danger" data-testid="create-ticket-ref-error">
+        {refError}
+      </div>
+    );
+  }
+
+  // ── Success state ─────────────────────────────────────────────────────
+
+  if (formState === "success") {
+    return (
+      <div data-testid="create-ticket-success">
+        <div
+          className="alert d-flex flex-column gap-2 p-4"
+          style={{ backgroundColor: "#EAF6EF", border: "1px solid #0B7A46", color: "#065F46" }}
+        >
+          <strong style={{ fontSize: "1.1rem" }}>✅ Ticket created successfully!</strong>
+          <span>
+            Your Ticket Number is:{" "}
+            <strong data-testid="success-ticket-number">{successTicketNumber}</strong>
+          </span>
+          {apiError && (
+            <div className="alert alert-warning mb-0 py-2" style={{ fontSize: "0.85rem" }}>
+              {apiError}
+            </div>
+          )}
+        </div>
+        <button
+          type="button"
+          className="btn mt-3"
+          style={{ backgroundColor: "#006B3C", color: "white" }}
+          onClick={onCancel}
+          data-testid="back-btn"
+        >
+          ← Back
+        </button>
+      </div>
+    );
+  }
+
+  // ── Main form ─────────────────────────────────────────────────────────
+
+  return (
+    <div style={{ maxWidth: 760 }} data-testid="create-ticket-form">
+      <h1 className="h4 fw-bold mb-4" style={{ color: "#1A2E22" }}>
+        Create Ticket
+      </h1>
+
+      {/* API error banner (preserves form values) */}
+      {formState === "error" && apiError && (
+        <div className="alert alert-danger mb-4" role="alert" data-testid="api-error-banner">
+          {apiError}
+        </div>
+      )}
+
+      <form onSubmit={handleSubmit} noValidate>
+        {/* ── System-generated fields (read-only) ── */}
+        <div className="row mb-3">
+          <div className="col-md-6 mb-3 mb-md-0">
+            <label style={labelStyle}>Ticket Number</label>
+            <input
+              className={readonlyClass}
+              readOnly
+              value="Will be assigned on submission"
+              style={{ backgroundColor: "#F0F4F2", color: "#5A6E62" }}
+              aria-label="Ticket Number — assigned on submission"
+            />
+          </div>
+          <div className="col-md-6">
+            <label style={labelStyle}>Ticket Date</label>
+            <input
+              className={readonlyClass}
+              readOnly
+              value="Will be assigned on submission"
+              style={{ backgroundColor: "#F0F4F2", color: "#5A6E62" }}
+              aria-label="Ticket Date — assigned on submission"
+            />
+          </div>
+        </div>
+
+        {/* ── Requester (read-only, pre-filled from context) ── */}
+        <div className="row mb-3">
+          <div className="col-md-6 mb-3 mb-md-0">
+            <label style={labelStyle}>Requester</label>
+            <input
+              className={readonlyClass}
+              readOnly
+              value={currentRequester?.name ?? ""}
+              style={{ backgroundColor: "#F0F4F2" }}
+              data-testid="requester-readonly"
+              aria-label="Requester"
+            />
+          </div>
+
+          {/* ── Requested Priority ── */}
+          <div className="col-md-6">
+            <label htmlFor="priority-select" style={labelStyle}>
+              Requested Priority{" "}
+              <span className="text-danger" aria-hidden="true">*</span>
+              <span className="visually-hidden">(required)</span>
+            </label>
+            <select
+              id="priority-select"
+              className={`${inputClass}${fieldErrors.requestedPriority ? " is-invalid" : ""}`}
+              value={requestedPriority}
+              onChange={(e) => setRequestedPriority(e.target.value as Priority | "")}
+              disabled={isSubmitting}
+              aria-required="true"
+              data-testid="priority-select"
+            >
+              <option value="">Select priority…</option>
+              <option value="LOW">Low</option>
+              <option value="MEDIUM">Medium</option>
+              <option value="HIGH">High</option>
+            </select>
+            <FieldError name="requestedPriority" />
+          </div>
+        </div>
+
+        {/* ── Category + Related System ── */}
+        <div className="row mb-3">
+          <div className="col-md-6 mb-3 mb-md-0">
+            <label htmlFor="category-select" style={labelStyle}>
+              Category{" "}
+              <span className="text-danger" aria-hidden="true">*</span>
+              <span className="visually-hidden">(required)</span>
+            </label>
+            <select
+              id="category-select"
+              className={`${inputClass}${fieldErrors.categoryId ? " is-invalid" : ""}`}
+              value={categoryId}
+              onChange={(e) => setCategoryId(e.target.value)}
+              disabled={isSubmitting}
+              aria-required="true"
+              data-testid="category-select"
+            >
+              <option value="">Select category…</option>
+              {categories.map((c) => (
+                <option key={c.id} value={c.id}>{c.name}</option>
+              ))}
+            </select>
+            <FieldError name="categoryId" />
+          </div>
+
+          <div className="col-md-6">
+            <label htmlFor="system-select" style={labelStyle}>
+              Related System{" "}
+              <span className="text-danger" aria-hidden="true">*</span>
+              <span className="visually-hidden">(required)</span>
+            </label>
+            <select
+              id="system-select"
+              className={`${inputClass}${fieldErrors.relatedSystemId ? " is-invalid" : ""}`}
+              value={relatedSystemId}
+              onChange={(e) => setRelatedSystemId(e.target.value)}
+              disabled={isSubmitting}
+              aria-required="true"
+              data-testid="system-select"
+            >
+              <option value="">Select system…</option>
+              {relatedSystems.map((s) => (
+                <option key={s.id} value={s.id}>{s.name}</option>
+              ))}
+            </select>
+            <FieldError name="relatedSystemId" />
+          </div>
+        </div>
+
+        {/* ── Summary ── */}
+        <div className="mb-3">
+          <label htmlFor="summary-input" style={labelStyle}>
+            Ticket Summary{" "}
+            <span className="text-danger" aria-hidden="true">*</span>
+            <span className="visually-hidden">(required)</span>
+          </label>
+          <input
+            id="summary-input"
+            type="text"
+            className={`${inputClass}${fieldErrors.summary ? " is-invalid" : ""}`}
+            value={summary}
+            onChange={(e) => setSummary(e.target.value)}
+            disabled={isSubmitting}
+            maxLength={150}
+            aria-required="true"
+            data-testid="summary-input"
+            placeholder="Brief description of the issue (5–150 characters)"
+          />
+          <FieldError name="summary" />
+        </div>
+
+        {/* ── Description ── */}
+        <div className="mb-3">
+          <label htmlFor="description-input" style={labelStyle}>
+            Description{" "}
+            <span className="text-danger" aria-hidden="true">*</span>
+            <span className="visually-hidden">(required)</span>
+          </label>
+          <textarea
+            id="description-input"
+            className={`${inputClass}${fieldErrors.description ? " is-invalid" : ""}`}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            disabled={isSubmitting}
+            rows={5}
+            maxLength={2000}
+            aria-required="true"
+            data-testid="description-input"
+            placeholder="Detailed description of the issue (10–2000 characters)"
+            style={{ resize: "vertical", minHeight: 120 }}
+          />
+          <FieldError name="description" />
+        </div>
+
+        {/* ── Attachments ── */}
+        <div className="mb-4">
+          <label style={labelStyle}>Attachments (optional)</label>
+          <div
+            className="border rounded p-3"
+            style={{ backgroundColor: "#F5F7F6", borderColor: "#D1D9D5" }}
+          >
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              onChange={handleFileChange}
+              disabled={isSubmitting}
+              className="form-control mb-2"
+              data-testid="file-input"
+              aria-label="Attach files (JPG, PNG, WEBP, PDF, max 5 MB each)"
+            />
+            <p style={{ fontSize: "0.8rem", color: "#5A6E62", margin: 0 }}>
+              Allowed: JPG, PNG, WEBP, PDF · Max 5 MB per file · Max {MAX_FILES} files
+            </p>
+
+            {/* Pending file list */}
+            {pendingFiles.length > 0 && (
+              <ul className="list-group mt-2" data-testid="pending-files-list">
+                {pendingFiles.map(({ file, error }, i) => (
+                  <li
+                    key={i}
+                    className={`list-group-item d-flex justify-content-between align-items-start py-2 ${error ? "list-group-item-danger" : ""}`}
+                    data-testid={`pending-file-${i}`}
+                  >
+                    <div>
+                      <span style={{ fontSize: "0.875rem" }}>{file.name}</span>
+                      {error && (
+                        <div
+                          className="text-danger"
+                          style={{ fontSize: "0.78rem" }}
+                          data-testid={`file-error-${i}`}
+                        >
+                          {error}
+                        </div>
+                      )}
+                    </div>
+                    <button
+                      type="button"
+                      className="btn btn-sm btn-outline-danger ms-2"
+                      onClick={() => removePendingFile(i)}
+                      disabled={isSubmitting}
+                      aria-label={`Remove ${file.name}`}
+                    >
+                      ✕
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+
+        {/* ── Actions ── */}
+        <div className="d-flex justify-content-end gap-2">
+          <button
+            type="button"
+            className="btn btn-outline-secondary"
+            onClick={onCancel}
+            disabled={isSubmitting}
+            data-testid="cancel-btn"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="btn text-white fw-semibold"
+            style={{ backgroundColor: isSubmitting ? "#5A6E62" : "#006B3C" }}
+            disabled={isSubmitting}
+            data-testid="submit-btn"
+          >
+            {isSubmitting ? (
+              <>
+                <span
+                  className="spinner-border spinner-border-sm me-2"
+                  role="status"
+                  aria-hidden="true"
+                />
+                Submitting…
+              </>
+            ) : (
+              "Submit Ticket →"
+            )}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+export default CreateTicket;

--- a/client/tests/lab-02/CreateTicket.test.tsx
+++ b/client/tests/lab-02/CreateTicket.test.tsx
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CreateTicket } from "../../src/components/CreateTicket.js";
+import * as api from "../../src/api.js";
+import { RequesterProvider, useRequester } from "../../src/context/RequesterContext.js";
+
+// ── Constants ─────────────────────────────────────────────────────────────
+
+const MOCK_CATEGORIES = [
+  { id: 1, name: "Account and Access" },
+  { id: 2, name: "Hardware" },
+];
+const MOCK_SYSTEMS = [
+  { id: 1, name: "Corporate Laptop" },
+  { id: 2, name: "Email" },
+];
+const MOCK_TICKET = {
+  id: 1,
+  ticketNumber: "TKT-2026-000001",
+  requesterId: 1,
+  categoryId: 2,
+  relatedSystemId: 1,
+  summary: "Laptop battery drains quickly",
+  description: "Battery drains much faster than usual after the last update.",
+  requestedPriority: "MEDIUM" as const,
+  status: "NEW",
+  ticketDate: new Date().toISOString(),
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+const MOCK_REQUESTER = { id: 1, name: "Jennifer Anderson", email: "jennifer@example.com" };
+
+// ── Helper: render CreateTicket with a pre-selected requester ─────────────
+
+/**
+ * Seeds the RequesterContext with a mock requester, then renders CreateTicket.
+ * Uses a stable inner component that calls selectRequester during render.
+ */
+function renderWithRequester(onCancel = vi.fn()) {
+  function Seeder() {
+    const { selectRequester, currentRequester } = useRequester();
+    if (!currentRequester) {
+      // Call during render phase is fine here — setState during render is
+      // acceptable in React when used to initialise state from a prop/context.
+      // We use act to flush any resulting state updates.
+      selectRequester(MOCK_REQUESTER);
+    }
+    return <CreateTicket onCancel={onCancel} />;
+  }
+
+  return render(
+    <RequesterProvider>
+      <Seeder />
+    </RequesterProvider>
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe("CreateTicket component", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(api, "fetchCategories").mockResolvedValue(MOCK_CATEGORIES);
+    vi.spyOn(api, "fetchRelatedSystems").mockResolvedValue(MOCK_SYSTEMS);
+  });
+
+  // ── Reference data states ──────────────────────────────────────────────
+
+  it("shows a loading spinner while reference data is being fetched", () => {
+    vi.spyOn(api, "fetchCategories").mockReturnValue(new Promise(() => {}));
+    vi.spyOn(api, "fetchRelatedSystems").mockReturnValue(new Promise(() => {}));
+    renderWithRequester();
+    expect(screen.getByTestId("create-ticket-ref-loading")).toBeInTheDocument();
+  });
+
+  it("renders the form after reference data loads", async () => {
+    renderWithRequester();
+    await waitFor(() => {
+      expect(screen.getByTestId("create-ticket-form")).toBeInTheDocument();
+    });
+  });
+
+  it("shows error state when reference data fails to load", async () => {
+    vi.spyOn(api, "fetchCategories").mockRejectedValue(new Error("Network error"));
+    vi.spyOn(api, "fetchRelatedSystems").mockRejectedValue(new Error("Network error"));
+    renderWithRequester();
+    await waitFor(() => {
+      expect(screen.getByTestId("create-ticket-ref-error")).toBeInTheDocument();
+    });
+  });
+
+  // ── Required field inputs present ─────────────────────────────────────
+
+  it("renders all required field inputs after loading", async () => {
+    renderWithRequester();
+    await waitFor(() => expect(screen.getByTestId("create-ticket-form")).toBeInTheDocument());
+    expect(screen.getByTestId("summary-input")).toBeInTheDocument();
+    expect(screen.getByTestId("description-input")).toBeInTheDocument();
+    expect(screen.getByTestId("category-select")).toBeInTheDocument();
+    expect(screen.getByTestId("system-select")).toBeInTheDocument();
+    expect(screen.getByTestId("priority-select")).toBeInTheDocument();
+  });
+
+  it("pre-fills the Requester field as read-only from context", async () => {
+    renderWithRequester();
+    await waitFor(() => expect(screen.getByTestId("create-ticket-form")).toBeInTheDocument());
+    expect(screen.getByTestId("requester-readonly")).toHaveValue("Jennifer Anderson");
+  });
+
+  // ── Field-level validation errors ─────────────────────────────────────
+
+  it("shows a summary error when summary is empty on submit", async () => {
+    renderWithRequester();
+    await waitFor(() => expect(screen.getByTestId("submit-btn")).toBeInTheDocument());
+    await userEvent.click(screen.getByTestId("submit-btn"));
+    expect(screen.getByTestId("error-summary")).toHaveTextContent("Summary is required.");
+  });
+
+  it("shows a summary error when summary is too short", async () => {
+    renderWithRequester();
+    await waitFor(() => expect(screen.getByTestId("submit-btn")).toBeInTheDocument());
+    await userEvent.type(screen.getByTestId("summary-input"), "Hi");
+    await userEvent.click(screen.getByTestId("submit-btn"));
+    expect(screen.getByTestId("error-summary")).toHaveTextContent("at least 5 characters");
+  });
+
+  it("shows a description error when description is empty on submit", async () => {
+    renderWithRequester();
+    await waitFor(() => expect(screen.getByTestId("submit-btn")).toBeInTheDocument());
+    await userEvent.click(screen.getByTestId("submit-btn"));
+    expect(screen.getByTestId("error-description")).toBeInTheDocument();
+  });
+
+  it("shows a description error when description is too short", async () => {
+    renderWithRequester();
+    await waitFor(() => expect(screen.getByTestId("submit-btn")).toBeInTheDocument());
+    await userEvent.type(screen.getByTestId("description-input"), "Too short");
+    await userEvent.click(screen.getByTestId("submit-btn"));
+    expect(screen.getByTestId("error-description")).toHaveTextContent("at least 10 characters");
+  });
+
+  it("does not call the API when there are validation errors", async () => {
+    const spy = vi.spyOn(api, "createTicket");
+    renderWithRequester();
+    await waitFor(() => expect(screen.getByTestId("submit-btn")).toBeInTheDocument());
+    await userEvent.click(screen.getByTestId("submit-btn"));
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  // ── File validation ────────────────────────────────────────────────────
+
+  it("shows an error for an unsupported file type", async () => {
+    renderWithRequester();
+    await waitFor(() => expect(screen.getByTestId("file-input")).toBeInTheDocument());
+    const badFile = new File(["content"], "malware.exe", { type: "application/octet-stream" });
+    await userEvent.upload(screen.getByTestId("file-input"), badFile);
+    await waitFor(() => {
+      expect(screen.getByTestId("file-error-0")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("file-error-0")).toHaveTextContent("not an allowed file type");
+  });
+
+  it("shows an error for a file that exceeds 5 MB", async () => {
+    renderWithRequester();
+    await waitFor(() => expect(screen.getByTestId("file-input")).toBeInTheDocument());
+    const bigContent = new Uint8Array(6 * 1024 * 1024);
+    const bigFile = new File([bigContent], "large.jpg", { type: "image/jpeg" });
+    await userEvent.upload(screen.getByTestId("file-input"), bigFile);
+    await waitFor(() => {
+      expect(screen.getByTestId("file-error-0")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("file-error-0")).toHaveTextContent("5 MB");
+  });
+
+  it("accepts a valid PDF file without showing an error", async () => {
+    renderWithRequester();
+    await waitFor(() => expect(screen.getByTestId("file-input")).toBeInTheDocument());
+    const validFile = new File(["pdf content"], "report.pdf", { type: "application/pdf" });
+    await userEvent.upload(screen.getByTestId("file-input"), validFile);
+    await waitFor(() => {
+      expect(screen.getByTestId("pending-file-0")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("file-error-0")).not.toBeInTheDocument();
+  });
+
+  // ── Busy / disabled state ──────────────────────────────────────────────
+
+  it("disables the submit button and shows spinner while submitting", async () => {
+    vi.spyOn(api, "createTicket").mockReturnValue(new Promise(() => {}));
+    renderWithRequester();
+    await waitFor(() => expect(screen.getByTestId("submit-btn")).toBeInTheDocument());
+
+    await userEvent.type(screen.getByTestId("summary-input"), "Valid summary text");
+    await userEvent.type(screen.getByTestId("description-input"), "Valid description that is long enough.");
+    await userEvent.selectOptions(screen.getByTestId("category-select"), "2");
+    await userEvent.selectOptions(screen.getByTestId("system-select"), "1");
+    await userEvent.selectOptions(screen.getByTestId("priority-select"), "MEDIUM");
+    await userEvent.click(screen.getByTestId("submit-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("submit-btn")).toBeDisabled();
+    });
+    expect(screen.getByTestId("submit-btn")).toHaveTextContent("Submitting");
+  });
+
+  // ── Success state ──────────────────────────────────────────────────────
+
+  it("shows the success state with the generated Ticket Number", async () => {
+    vi.spyOn(api, "createTicket").mockResolvedValue(MOCK_TICKET);
+    renderWithRequester();
+    await waitFor(() => expect(screen.getByTestId("submit-btn")).toBeInTheDocument());
+
+    await userEvent.type(screen.getByTestId("summary-input"), "Valid summary text");
+    await userEvent.type(screen.getByTestId("description-input"), "Valid description that is long enough.");
+    await userEvent.selectOptions(screen.getByTestId("category-select"), "2");
+    await userEvent.selectOptions(screen.getByTestId("system-select"), "1");
+    await userEvent.selectOptions(screen.getByTestId("priority-select"), "MEDIUM");
+    await userEvent.click(screen.getByTestId("submit-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("create-ticket-success")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("success-ticket-number")).toHaveTextContent("TKT-2026-000001");
+  });
+
+  // ── API failure — form values preserved ───────────────────────────────
+
+  it("shows API error banner and preserves form values on backend failure", async () => {
+    vi.spyOn(api, "createTicket").mockRejectedValue(new Error("Server error"));
+    renderWithRequester();
+    await waitFor(() => expect(screen.getByTestId("submit-btn")).toBeInTheDocument());
+
+    const summaryText = "Valid summary text";
+    await userEvent.type(screen.getByTestId("summary-input"), summaryText);
+    await userEvent.type(screen.getByTestId("description-input"), "Valid description that is long enough.");
+    await userEvent.selectOptions(screen.getByTestId("category-select"), "2");
+    await userEvent.selectOptions(screen.getByTestId("system-select"), "1");
+    await userEvent.selectOptions(screen.getByTestId("priority-select"), "MEDIUM");
+    await userEvent.click(screen.getByTestId("submit-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("api-error-banner")).toBeInTheDocument();
+    });
+    // Form values preserved after failure
+    expect(screen.getByTestId("summary-input")).toHaveValue(summaryText);
+  });
+});

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,11 +10,13 @@
       "dependencies": {
         "@prisma/client": "^5.22.0",
         "cors": "^2.8.5",
-        "express": "^4.21.2"
+        "express": "^4.21.2",
+        "multer": "^2.0.2"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
+        "@types/multer": "^1.4.12",
         "@types/node": "^22.10.2",
         "@types/supertest": "^6.0.2",
         "prisma": "^5.22.0",
@@ -1023,6 +1025,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/multer": {
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.12.tgz",
+      "integrity": "sha512-pQ2hoqvXiJt2FP9WQVLPRO+AmiIm/ZYkavPlIQnx282u4ZrVdztx0pkh3jjpQt0Kz+YI0YhSG264y08UJKoUQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.20.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
@@ -1230,6 +1242,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -1282,6 +1300,23 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -1380,6 +1415,21 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
       }
     },
     "node_modules/content-disposition": {
@@ -2035,6 +2085,25 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.18",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
@@ -2245,6 +2314,20 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/rollup": {
@@ -2482,6 +2565,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/superagent": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
@@ -2651,6 +2751,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -2680,6 +2786,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/server/package.json
+++ b/server/package.json
@@ -11,15 +11,19 @@
     "prisma:seed": "tsx prisma/seed.ts",
     "test": "vitest run"
   },
-  "prisma": { "seed": "tsx prisma/seed.ts" },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
+  },
   "dependencies": {
     "@prisma/client": "^5.22.0",
     "cors": "^2.8.5",
-    "express": "^4.21.2"
+    "express": "^4.21.2",
+    "multer": "^2.0.2"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
+    "@types/multer": "^1.4.12",
     "@types/node": "^22.10.2",
     "@types/supertest": "^6.0.2",
     "prisma": "^5.22.0",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -3,17 +3,21 @@ import cors from "cors";
 import healthRouter from "./routes/health.router.js";
 import categoriesRouter from "./routes/categories.router.js";
 import requestersRouter from "./routes/requesters.router.js";
+import relatedSystemsRouter from "./routes/relatedSystems.router.js";
+import ticketsRouter from "./routes/tickets.router.js";
 
 // The Express app is exported separately from app.listen() (see index.ts) so
 // Supertest can import `app` without opening a port. Do not merge these files.
 export const app = express();
 
-app.use(cors());          // already wired: lets the Vite dev server call this API
+app.use(cors());
 app.use(express.json());
 
 // API routes
 app.use("/api/health", healthRouter);
 app.use("/api/categories", categoriesRouter);
 app.use("/api/requesters", requestersRouter);
+app.use("/api/related-systems", relatedSystemsRouter);
+app.use("/api/tickets", ticketsRouter);
 
 export default app;

--- a/server/src/controllers/attachments.controller.ts
+++ b/server/src/controllers/attachments.controller.ts
@@ -1,0 +1,121 @@
+import { Request, Response } from "express";
+import path from "path";
+import fs from "fs";
+import { getPrisma } from "../prisma.js";
+import {
+  isAllowedMimeType,
+  isAllowedFileSize,
+  MAX_ACTIVE_ATTACHMENTS,
+} from "../utils/attachmentValidation.js";
+
+/**
+ * POST /api/tickets/:ticketNumber/attachments
+ * Uploads a file attachment to an existing Ticket.
+ * Validates file type, size, and active attachment count.
+ * If the ticket exists but upload validation fails, the ticket is NOT rolled back.
+ */
+export const uploadAttachment = async (req: Request, res: Response): Promise<void> => {
+  const prisma = getPrisma();
+  const { ticketNumber } = req.params;
+  const requesterId = Number(req.body.requesterId);
+
+  // multer v2 stores file in req.file
+  const file = req.file as Express.Multer.File | undefined;
+
+  if (!requesterId || isNaN(requesterId)) {
+    // Clean up uploaded file if it slipped through
+    if (file?.path) fs.unlink(file.path, () => {});
+    res.status(400).json({
+      error: { code: "VALIDATION_ERROR", message: "requesterId is required." },
+    });
+    return;
+  }
+
+  if (!file) {
+    res.status(400).json({
+      error: { code: "VALIDATION_ERROR", message: "A file is required." },
+    });
+    return;
+  }
+
+  // Validate MIME type
+  if (!isAllowedMimeType(file.mimetype)) {
+    fs.unlink(file.path, () => {});
+    res.status(415).json({
+      error: {
+        code: "UNSUPPORTED_MEDIA_TYPE",
+        message: "Only JPG, PNG, WEBP, and PDF files are allowed.",
+      },
+    });
+    return;
+  }
+
+  // Validate file size
+  if (!isAllowedFileSize(file.size)) {
+    fs.unlink(file.path, () => {});
+    res.status(400).json({
+      error: { code: "FILE_TOO_LARGE", message: "File must be 5 MB or smaller." },
+    });
+    return;
+  }
+
+  try {
+    // Verify ticket exists and belongs to the requester
+    const ticket = await prisma.ticket.findUnique({ where: { ticketNumber } });
+    if (!ticket) {
+      fs.unlink(file.path, () => {});
+      res.status(404).json({ error: { code: "NOT_FOUND", message: "Ticket not found." } });
+      return;
+    }
+    if (ticket.requesterId !== requesterId) {
+      fs.unlink(file.path, () => {});
+      res.status(403).json({
+        error: { code: "FORBIDDEN", message: "You do not own this ticket." },
+      });
+      return;
+    }
+
+    // Check active attachment count
+    const activeCount = await prisma.attachment.count({
+      where: { ticketId: ticket.id, removedAt: null },
+    });
+    if (activeCount >= MAX_ACTIVE_ATTACHMENTS) {
+      fs.unlink(file.path, () => {});
+      res.status(409).json({
+        error: {
+          code: "ATTACHMENT_LIMIT_REACHED",
+          message: `A ticket can have at most ${MAX_ACTIVE_ATTACHMENTS} active attachments.`,
+        },
+      });
+      return;
+    }
+
+    // Persist attachment metadata
+    const attachment = await prisma.attachment.create({
+      data: {
+        ticketId:     ticket.id,
+        originalName: file.originalname,
+        storedPath:   file.path,
+        mimeType:     file.mimetype,
+        sizeBytes:    file.size,
+      },
+    });
+
+    // Return metadata only — never expose storedPath to the client
+    res.status(201).json({
+      id:           attachment.id,
+      originalName: attachment.originalName,
+      mimeType:     attachment.mimeType,
+      sizeBytes:    attachment.sizeBytes,
+      uploadedAt:   attachment.uploadedAt,
+      removedAt:    attachment.removedAt,
+      removalReason: attachment.removalReason,
+    });
+  } catch (err) {
+    console.error("Failed to upload attachment:", err);
+    if (file?.path) fs.unlink(file.path, () => {});
+    res.status(500).json({
+      error: { code: "SERVER_ERROR", message: "Unable to upload attachment. Please try again later." },
+    });
+  }
+};

--- a/server/src/controllers/relatedSystems.controller.ts
+++ b/server/src/controllers/relatedSystems.controller.ts
@@ -1,0 +1,20 @@
+import { Request, Response } from "express";
+import { getPrisma } from "../prisma.js";
+
+/**
+ * GET /api/related-systems
+ * Returns all active Related Systems ordered by name ascending.
+ */
+export const getRelatedSystems = async (_req: Request, res: Response): Promise<void> => {
+  try {
+    const systems = await getPrisma().relatedSystem.findMany({
+      where:   { isActive: true },
+      select:  { id: true, name: true },
+      orderBy: { name: "asc" },
+    });
+    res.status(200).json(systems);
+  } catch (err) {
+    console.error("Failed to fetch related systems:", err);
+    res.status(500).json({ error: "Unable to load related systems. Please try again later." });
+  }
+};

--- a/server/src/controllers/tickets.controller.ts
+++ b/server/src/controllers/tickets.controller.ts
@@ -1,0 +1,138 @@
+import { Request, Response } from "express";
+import { getPrisma } from "../prisma.js";
+import { generateTicketNumber } from "../utils/ticketNumber.js";
+
+const VALID_PRIORITIES = ["LOW", "MEDIUM", "HIGH"] as const;
+type Priority = typeof VALID_PRIORITIES[number];
+
+interface CreateTicketBody {
+  requesterId?: unknown;
+  categoryId?: unknown;
+  relatedSystemId?: unknown;
+  summary?: unknown;
+  description?: unknown;
+  requestedPriority?: unknown;
+}
+
+/**
+ * POST /api/tickets
+ * Creates a new Ticket for the specified Development Requester.
+ * Ticket Number and ticketDate are generated server-side.
+ * Default status is NEW.
+ */
+export const createTicket = async (req: Request, res: Response): Promise<void> => {
+  const prisma = getPrisma();
+  const body = req.body as CreateTicketBody;
+
+  // ── Validation ──────────────────────────────────────────────────────────
+  const errors: Record<string, string> = {};
+
+  const requesterId = Number(body.requesterId);
+  if (!body.requesterId || isNaN(requesterId)) {
+    errors.requesterId = "Requester ID is required and must be a number.";
+  }
+
+  const categoryId = Number(body.categoryId);
+  if (!body.categoryId || isNaN(categoryId)) {
+    errors.categoryId = "Category is required.";
+  }
+
+  const relatedSystemId = Number(body.relatedSystemId);
+  if (!body.relatedSystemId || isNaN(relatedSystemId)) {
+    errors.relatedSystemId = "Related System is required.";
+  }
+
+  const summary = typeof body.summary === "string" ? body.summary.trim() : "";
+  if (!summary) {
+    errors.summary = "Summary is required.";
+  } else if (summary.length < 5) {
+    errors.summary = "Summary must be at least 5 characters.";
+  } else if (summary.length > 150) {
+    errors.summary = "Summary must be 150 characters or fewer.";
+  }
+
+  const description = typeof body.description === "string" ? body.description.trim() : "";
+  if (!description) {
+    errors.description = "Description is required.";
+  } else if (description.length < 10) {
+    errors.description = "Description must be at least 10 characters.";
+  } else if (description.length > 2000) {
+    errors.description = "Description must be 2000 characters or fewer.";
+  }
+
+  const requestedPriority = typeof body.requestedPriority === "string"
+    ? body.requestedPriority.toUpperCase()
+    : "";
+  if (!requestedPriority || !VALID_PRIORITIES.includes(requestedPriority as Priority)) {
+    errors.requestedPriority = "Requested Priority must be LOW, MEDIUM, or HIGH.";
+  }
+
+  if (Object.keys(errors).length > 0) {
+    res.status(400).json({
+      error: { code: "VALIDATION_ERROR", message: "Validation failed.", fields: errors },
+    });
+    return;
+  }
+
+  try {
+    // Verify requester exists and is active
+    const requester = await prisma.requesterUser.findFirst({
+      where: { id: requesterId, isActive: true },
+    });
+    if (!requester) {
+      res.status(400).json({
+        error: { code: "INVALID_REQUESTER", message: "Requester not found or is inactive." },
+      });
+      return;
+    }
+
+    // Verify category exists
+    const category = await prisma.category.findUnique({ where: { id: categoryId } });
+    if (!category) {
+      res.status(400).json({
+        error: { code: "INVALID_REFERENCE", message: "Category not found." },
+      });
+      return;
+    }
+
+    // Verify related system exists and is active
+    const relatedSystem = await prisma.relatedSystem.findFirst({
+      where: { id: relatedSystemId, isActive: true },
+    });
+    if (!relatedSystem) {
+      res.status(400).json({
+        error: { code: "INVALID_REFERENCE", message: "Related System not found or is inactive." },
+      });
+      return;
+    }
+
+    // Generate unique Ticket Number
+    const ticketNumber = await generateTicketNumber(prisma);
+
+    // Create the ticket
+    const ticket = await prisma.ticket.create({
+      data: {
+        ticketNumber,
+        requesterId,
+        categoryId,
+        relatedSystemId,
+        summary,
+        description,
+        requestedPriority: requestedPriority as Priority,
+        status: "NEW",
+      },
+      include: {
+        requester:     { select: { id: true, name: true } },
+        category:      { select: { id: true, name: true } },
+        relatedSystem: { select: { id: true, name: true } },
+      },
+    });
+
+    res.status(201).json(ticket);
+  } catch (err) {
+    console.error("Failed to create ticket:", err);
+    res.status(500).json({
+      error: { code: "SERVER_ERROR", message: "Unable to create ticket. Please try again later." },
+    });
+  }
+};

--- a/server/src/routes/relatedSystems.router.ts
+++ b/server/src/routes/relatedSystems.router.ts
@@ -1,0 +1,7 @@
+import { Router } from "express";
+import { getRelatedSystems } from "../controllers/relatedSystems.controller.js";
+
+const router = Router();
+router.get("/", getRelatedSystems);
+
+export default router;

--- a/server/src/routes/tickets.router.ts
+++ b/server/src/routes/tickets.router.ts
@@ -1,0 +1,50 @@
+import { Router, Request, Response, NextFunction } from "express";
+import multer from "multer";
+import path from "path";
+import { createTicket } from "../controllers/tickets.controller.js";
+import { uploadAttachment } from "../controllers/attachments.controller.js";
+
+// Store uploaded files in server/uploads/ with a unique name
+const storage = multer.diskStorage({
+  destination: (_req, _file, cb) => {
+    cb(null, "uploads/");
+  },
+  filename: (_req, file, cb) => {
+    const unique = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
+    const ext = path.extname(file.originalname);
+    cb(null, `${unique}${ext}`);
+  },
+});
+
+const upload = multer({
+  storage,
+  limits: { fileSize: 5 * 1024 * 1024 }, // 5 MB hard limit
+});
+
+const router = Router();
+
+// POST /api/tickets — create a new ticket (JSON body, no file)
+router.post("/", createTicket);
+
+// POST /api/tickets/:ticketNumber/attachments — upload one file to an existing ticket
+router.post(
+  "/:ticketNumber/attachments",
+  (req: Request, res: Response, next: NextFunction) => {
+    upload.single("file")(req, res, (err: unknown) => {
+      if (err instanceof multer.MulterError && err.code === "LIMIT_FILE_SIZE") {
+        res.status(400).json({
+          error: { code: "FILE_TOO_LARGE", message: "File must be 5 MB or smaller." },
+        });
+        return;
+      }
+      if (err) {
+        next(err);
+        return;
+      }
+      next();
+    });
+  },
+  uploadAttachment
+);
+
+export default router;

--- a/server/src/utils/attachmentValidation.ts
+++ b/server/src/utils/attachmentValidation.ts
@@ -1,0 +1,25 @@
+/**
+ * Attachment validation rules (fixed by spec):
+ *   - Allowed MIME types: JPG/JPEG, PNG, WEBP, PDF
+ *   - Maximum file size: 5 MB
+ *   - Maximum active attachments per ticket: 5
+ */
+
+export const ALLOWED_MIME_TYPES = new Set([
+  "image/jpeg",
+  "image/jpg",
+  "image/png",
+  "image/webp",
+  "application/pdf",
+]);
+
+export const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
+export const MAX_ACTIVE_ATTACHMENTS = 5;
+
+export function isAllowedMimeType(mimeType: string): boolean {
+  return ALLOWED_MIME_TYPES.has(mimeType.toLowerCase());
+}
+
+export function isAllowedFileSize(sizeBytes: number): boolean {
+  return sizeBytes <= MAX_FILE_SIZE_BYTES;
+}

--- a/server/src/utils/ticketNumber.ts
+++ b/server/src/utils/ticketNumber.ts
@@ -1,0 +1,21 @@
+/**
+ * Generates a unique Ticket Number in the format TKT-YYYY-NNNNNN.
+ * YYYY = current year, NNNNNN = zero-padded sequential integer from the DB.
+ *
+ * Strategy: uses MAX(id) + 1 across all tickets for the sequence number.
+ * This is simple, collision-free within a single-process server, and produces
+ * human-readable sortable numbers without a separate counter table.
+ */
+import { PrismaClient } from "@prisma/client";
+
+export async function generateTicketNumber(prisma: PrismaClient): Promise<string> {
+  const year = new Date().getFullYear();
+
+  // Count all tickets ever created (including soft-deleted if any in future)
+  // to get the next sequence number.
+  const count = await prisma.ticket.count();
+  const sequence = count + 1;
+  const padded = String(sequence).padStart(6, "0");
+
+  return `TKT-${year}-${padded}`;
+}

--- a/server/tests/lab-02/create-ticket.api.test.ts
+++ b/server/tests/lab-02/create-ticket.api.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import { app } from "../../src/app.js";
+
+// ── Shared mock data ──────────────────────────────────────────────────────
+
+const MOCK_REQUESTER    = { id: 1, name: "Jennifer Anderson", isActive: true };
+const MOCK_CATEGORY     = { id: 2, name: "Hardware" };
+const MOCK_SYSTEM       = { id: 3, name: "Corporate Laptop", isActive: true };
+const MOCK_TICKET = {
+  id: 1,
+  ticketNumber: "TKT-2026-000001",
+  requesterId: 1,
+  categoryId: 2,
+  relatedSystemId: 3,
+  summary: "Laptop battery drains quickly",
+  description: "My laptop battery drains much faster than usual after last update.",
+  requestedPriority: "MEDIUM",
+  status: "NEW",
+  ticketDate: new Date().toISOString(),
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  requester:     { id: 1, name: "Jennifer Anderson" },
+  category:      { id: 2, name: "Hardware" },
+  relatedSystem: { id: 3, name: "Corporate Laptop" },
+};
+
+// ── Prisma mock ───────────────────────────────────────────────────────────
+
+vi.mock("../../src/prisma.js", () => ({
+  getPrisma: () => ({
+    requesterUser: {
+      findFirst: vi.fn().mockResolvedValue(MOCK_REQUESTER),
+    },
+    category: {
+      findUnique: vi.fn().mockResolvedValue(MOCK_CATEGORY),
+    },
+    relatedSystem: {
+      findFirst: vi.fn().mockResolvedValue(MOCK_SYSTEM),
+    },
+    ticket: {
+      count:  vi.fn().mockResolvedValue(0),
+      create: vi.fn().mockResolvedValue(MOCK_TICKET),
+    },
+    attachment: {
+      count:  vi.fn().mockResolvedValue(0),
+      create: vi.fn(),
+    },
+  }),
+}));
+
+// ── Valid body helper ─────────────────────────────────────────────────────
+
+const VALID_BODY = {
+  requesterId:       1,
+  categoryId:        2,
+  relatedSystemId:   3,
+  summary:           "Laptop battery drains quickly",
+  description:       "My laptop battery drains much faster than usual after last update.",
+  requestedPriority: "MEDIUM",
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe("POST /api/tickets", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // Happy path
+  it("returns 201 with a ticket containing a generated ticketNumber", async () => {
+    const res = await request(app).post("/api/tickets").send(VALID_BODY);
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty("ticketNumber");
+    expect(res.body.ticketNumber).toMatch(/^TKT-\d{4}-\d{6}$/);
+  });
+
+  it("returns 201 with status NEW", async () => {
+    const res = await request(app).post("/api/tickets").send(VALID_BODY);
+    expect(res.status).toBe(201);
+    expect(res.body.status).toBe("NEW");
+  });
+
+  it("returns 201 with requester, category, and relatedSystem embedded", async () => {
+    const res = await request(app).post("/api/tickets").send(VALID_BODY);
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty("requester");
+    expect(res.body).toHaveProperty("category");
+    expect(res.body).toHaveProperty("relatedSystem");
+  });
+
+  // Validation — missing fields
+  it("returns 400 when summary is missing", async () => {
+    const res = await request(app)
+      .post("/api/tickets")
+      .send({ ...VALID_BODY, summary: "" });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+    expect(res.body.error.fields).toHaveProperty("summary");
+  });
+
+  it("returns 400 when summary is too short (< 5 chars)", async () => {
+    const res = await request(app)
+      .post("/api/tickets")
+      .send({ ...VALID_BODY, summary: "Hi" });
+    expect(res.status).toBe(400);
+    expect(res.body.error.fields).toHaveProperty("summary");
+  });
+
+  it("returns 400 when summary is too long (> 150 chars)", async () => {
+    const res = await request(app)
+      .post("/api/tickets")
+      .send({ ...VALID_BODY, summary: "x".repeat(151) });
+    expect(res.status).toBe(400);
+    expect(res.body.error.fields).toHaveProperty("summary");
+  });
+
+  it("returns 400 when description is missing", async () => {
+    const res = await request(app)
+      .post("/api/tickets")
+      .send({ ...VALID_BODY, description: "" });
+    expect(res.status).toBe(400);
+    expect(res.body.error.fields).toHaveProperty("description");
+  });
+
+  it("returns 400 when description is too short (< 10 chars)", async () => {
+    const res = await request(app)
+      .post("/api/tickets")
+      .send({ ...VALID_BODY, description: "Too short" });
+    expect(res.status).toBe(400);
+    expect(res.body.error.fields).toHaveProperty("description");
+  });
+
+  it("returns 400 when requestedPriority is invalid", async () => {
+    const res = await request(app)
+      .post("/api/tickets")
+      .send({ ...VALID_BODY, requestedPriority: "URGENT" });
+    expect(res.status).toBe(400);
+    expect(res.body.error.fields).toHaveProperty("requestedPriority");
+  });
+
+  it("returns 400 when categoryId is missing", async () => {
+    const { categoryId: _, ...body } = VALID_BODY;
+    const res = await request(app).post("/api/tickets").send(body);
+    expect(res.status).toBe(400);
+    expect(res.body.error.fields).toHaveProperty("categoryId");
+  });
+
+  it("returns 400 when requesterId is missing", async () => {
+    const { requesterId: _, ...body } = VALID_BODY;
+    const res = await request(app).post("/api/tickets").send(body);
+    expect(res.status).toBe(400);
+    expect(res.body.error.fields).toHaveProperty("requesterId");
+  });
+
+  // Multiple validation errors returned at once
+  it("returns all field errors when multiple fields are invalid", async () => {
+    const res = await request(app).post("/api/tickets").send({});
+    expect(res.status).toBe(400);
+    const fields = res.body.error.fields;
+    expect(fields).toHaveProperty("requesterId");
+    expect(fields).toHaveProperty("categoryId");
+    expect(fields).toHaveProperty("summary");
+    expect(fields).toHaveProperty("description");
+    expect(fields).toHaveProperty("requestedPriority");
+  });
+});
+
+describe("POST /api/tickets/:ticketNumber/attachments", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 400 when no file is attached", async () => {
+    const res = await request(app)
+      .post("/api/tickets/TKT-2026-000001/attachments")
+      .field("requesterId", "1");
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 415 when file type is not allowed", async () => {
+    const res = await request(app)
+      .post("/api/tickets/TKT-2026-000001/attachments")
+      .field("requesterId", "1")
+      .attach("file", Buffer.from("fake exe content"), {
+        filename: "malware.exe",
+        contentType: "application/octet-stream",
+      });
+    expect(res.status).toBe(415);
+    expect(res.body.error.code).toBe("UNSUPPORTED_MEDIA_TYPE");
+  });
+
+  it("returns 400 when file exceeds 5 MB", async () => {
+    const bigBuffer = Buffer.alloc(6 * 1024 * 1024); // 6 MB
+    const res = await request(app)
+      .post("/api/tickets/TKT-2026-000001/attachments")
+      .field("requesterId", "1")
+      .attach("file", bigBuffer, {
+        filename: "large.jpg",
+        contentType: "image/jpeg",
+      });
+    expect(res.status).toBe(400);
+  });
+});

--- a/server/tests/lab-02/ticketNumber.unit.test.ts
+++ b/server/tests/lab-02/ticketNumber.unit.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from "vitest";
+import { generateTicketNumber } from "../../src/utils/ticketNumber.js";
+import { PrismaClient } from "@prisma/client";
+
+function makeMockPrisma(count: number) {
+  return {
+    ticket: { count: vi.fn().mockResolvedValue(count) },
+  } as unknown as PrismaClient;
+}
+
+describe("generateTicketNumber", () => {
+  it("produces a string matching TKT-YYYY-NNNNNN format", async () => {
+    const result = await generateTicketNumber(makeMockPrisma(0));
+    expect(result).toMatch(/^TKT-\d{4}-\d{6}$/);
+  });
+
+  it("uses the current year", async () => {
+    const year = new Date().getFullYear();
+    const result = await generateTicketNumber(makeMockPrisma(0));
+    expect(result).toContain(`TKT-${year}-`);
+  });
+
+  it("pads the sequence to 6 digits (first ticket → 000001)", async () => {
+    const result = await generateTicketNumber(makeMockPrisma(0));
+    expect(result).toMatch(/^TKT-\d{4}-000001$/);
+  });
+
+  it("increments correctly for subsequent tickets", async () => {
+    const result = await generateTicketNumber(makeMockPrisma(41));
+    expect(result).toMatch(/^TKT-\d{4}-000042$/);
+  });
+
+  it("two numbers generated with different counts are not equal", async () => {
+    const first  = await generateTicketNumber(makeMockPrisma(0));
+    const second = await generateTicketNumber(makeMockPrisma(1));
+    expect(first).not.toBe(second);
+  });
+});


### PR DESCRIPTION
Summary
- Implements the Create Ticket feature for the selected Development Requester, per docs/lab-02/specification.md and api-spec.md.

Changes
Types / Data
- Added shared interfaces: Category, RelatedSystem, Priority, Ticket, CreateTicketPayload, AttachmentMeta, SystemStatus

Frontend

- Create Ticket page/route, guarded so the form only renders once a Development Requester is selected (redirects to Requester - Selection otherwise)
- Form fields per ui-spec.md: Category, Related System, Requested Priority, Summary, Description, Attachments
- Read-only vs editable field distinction, required-field markers, and validation messaging
- Loading state while reference data (Categories, Related Systems) loads from the backend
- Success state showing the backend-generated Ticket Number

Backend integration

- Wired the form to POST /api/tickets with the selected requesterId attached
- Reference-data fetch for Categories and Related Systems

Out of scope (per contract)
- My Tickets list, Ticket Detail, and attachment lifecycle (separate Issues/PRs)
- Any IT Staff or workflow functionality