### PR TITLE
feature/lab2-my-tickets

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,103 +1,28 @@
 import { useState } from "react";
-import { checkSystem, Category } from "./api.js";
 import { useRequester } from "./context/RequesterContext.js";
 import { RequesterSelector } from "./components/RequesterSelector.js";
 import { AppShell } from "./components/AppShell.js";
+import { MyTickets } from "./components/MyTickets.js";
 import { CreateTicket } from "./components/CreateTicket.js";
 
-type Page = "home" | "create-ticket";
-type UiState = "idle" | "loading" | "success" | "error";
+type Page = "my-tickets" | "create-ticket";
 
 export default function App() {
   const { currentRequester } = useRequester();
+  const [page, setPage] = useState<Page>("my-tickets");
 
-  const [page,       setPage]       = useState<Page>("home");
-  const [state,      setState]      = useState<UiState>("idle");
-  const [categories, setCategories] = useState<Category[]>([]);
-  const [errorMsg,   setErrorMsg]   = useState<string | null>(null);
-
-  // If no Requester is selected, show the selector screen first.
+  // Gate: no requester selected → show selector screen
   if (!currentRequester) {
     return <RequesterSelector />;
   }
 
-  async function handleCheck() {
-    setState("loading");
-    setErrorMsg(null);
-    try {
-      const data = await checkSystem();
-      setCategories(data.categories);
-      setState("success");
-    } catch (err) {
-      console.error("System check failed:", err);
-      setErrorMsg("Unable to connect to TokTickIT API");
-      setState("error");
-    }
-  }
-
-  // ── Create Ticket page ────────────────────────────────────────────────
-
-  if (page === "create-ticket") {
-    return (
-      <AppShell activePage="create-ticket" onNavigate={setPage}>
-        <CreateTicket onCancel={() => setPage("home")} />
-      </AppShell>
-    );
-  }
-
-  // ── Home page ─────────────────────────────────────────────────────────
-
   return (
-    <AppShell activePage="home" onNavigate={setPage}>
-      <div style={{ maxWidth: 640 }}>
-        <h1 className="h3 mb-4">
-          TokTickIT <span className="text-success">IT Service Desk</span>
-        </h1>
-
-        <div className="mb-3">
-          <button
-            className="btn btn-success"
-            onClick={handleCheck}
-            disabled={state === "loading"}
-            data-testid="check-system-btn"
-          >
-            {state === "loading" ? "Loading…" : "Check System"}
-          </button>
-        </div>
-
-        {state === "loading" && (
-          <div className="alert alert-info py-2" data-testid="loading-indicator">
-            Checking system status...
-          </div>
-        )}
-
-        {state === "success" && (
-          <>
-            <div className="mt-3 mb-3" data-testid="online-status">
-              <span className="badge bg-success fs-6">System Status: Online</span>
-            </div>
-            <div data-testid="categories-list">
-              <h2 className="h6 fw-semibold mb-2">Supported Request Categories</h2>
-              <ol>
-                {categories.map((cat) => (
-                  <li key={cat.id}>{cat.name}</li>
-                ))}
-              </ol>
-            </div>
-          </>
-        )}
-
-        {state === "error" && (
-          <div className="mt-3">
-            <div className="mb-2" data-testid="offline-status">
-              <span className="badge bg-danger fs-6">System Status: Offline</span>
-            </div>
-            <div className="alert alert-danger py-2" data-testid="health-error-message">
-              {errorMsg}
-            </div>
-          </div>
-        )}
-      </div>
+    <AppShell activePage={page} onNavigate={setPage}>
+      {page === "create-ticket" ? (
+        <CreateTicket onCancel={() => setPage("my-tickets")} />
+      ) : (
+        <MyTickets onCreateTicket={() => setPage("create-ticket")} />
+      )}
     </AppShell>
   );
 }

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -116,6 +116,70 @@ export async function checkSystem(): Promise<SystemStatus> {
 
 // ── Tickets ────────────────────────────────────────────────────────────────
 
+export interface TicketListParams {
+  requesterId: number;
+  search?:     string;
+  category?:   string;
+  priority?:   Priority;
+  status?:     string;
+  sort?:       "createdAt" | "updatedAt";
+  order?:      "asc" | "desc";
+  page?:       number;
+  pageSize?:   10 | 25 | 50;
+}
+
+export interface TicketListMeta {
+  page:       number;
+  pageSize:   number;
+  total:      number;
+  totalPages: number;
+}
+
+export interface TicketListResponse {
+  data: Ticket[];
+  meta: TicketListMeta;
+}
+
+/**
+ * GET /api/tickets — returns the Requester's own tickets with search/filter/sort/pagination.
+ */
+export async function fetchTickets(params: TicketListParams): Promise<TicketListResponse> {
+  const qs = new URLSearchParams();
+  qs.set("requesterId", String(params.requesterId));
+  if (params.search)   qs.set("search",   params.search);
+  if (params.category) qs.set("category", params.category);
+  if (params.priority) qs.set("priority", params.priority);
+  if (params.status)   qs.set("status",   params.status);
+  if (params.sort)     qs.set("sort",     params.sort);
+  if (params.order)    qs.set("order",    params.order);
+  if (params.page)     qs.set("page",     String(params.page));
+  if (params.pageSize) qs.set("pageSize", String(params.pageSize));
+
+  const response = await fetch(`${API_URL}/api/tickets?${qs.toString()}`);
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}));
+    throw new Error(body?.error?.message ?? `Failed to load tickets: ${response.status}`);
+  }
+  return response.json();
+}
+
+/**
+ * GET /api/tickets/:ticketNumber — returns one owned ticket with attachments.
+ */
+export async function fetchTicketByNumber(
+  ticketNumber: string,
+  requesterId: number
+): Promise<Ticket> {
+  const response = await fetch(
+    `${API_URL}/api/tickets/${ticketNumber}?requesterId=${requesterId}`
+  );
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}));
+    throw new Error(body?.error?.message ?? `Failed to load ticket: ${response.status}`);
+  }
+  return response.json();
+}
+
 /**
  * POST /api/tickets — creates a new ticket for the selected Requester.
  * Throws with parsed field errors on 400 validation failure.

--- a/client/src/components/AppShell.tsx
+++ b/client/src/components/AppShell.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from "react";
 import { useRequester } from "../context/RequesterContext.js";
 
-type Page = "home" | "create-ticket";
+type Page = "my-tickets" | "create-ticket";
 
 interface AppShellProps {
   children:    ReactNode;
@@ -35,7 +35,7 @@ export function AppShell({ children, activePage, onNavigate }: AppShellProps) {
         <button
           className="navbar-brand fw-bold text-white fs-5 btn p-0 border-0"
           style={{ letterSpacing: "0.02em", background: "none" }}
-          onClick={() => onNavigate?.("home")}
+          onClick={() => onNavigate?.("my-tickets")}
           aria-label="TokTickIT home"
         >
           🕐 TokTickIT
@@ -61,10 +61,10 @@ export function AppShell({ children, activePage, onNavigate }: AppShellProps) {
             <li className="nav-item">
               <button
                 className="nav-link text-white btn p-2 border-0"
-                style={navLinkStyle("home")}
-                onClick={() => onNavigate?.("home")}
+                style={navLinkStyle("my-tickets")}
+                onClick={() => onNavigate?.("my-tickets")}
                 data-testid="nav-my-tickets"
-                aria-current={activePage === "home" ? "page" : undefined}
+                aria-current={activePage === "my-tickets" ? "page" : undefined}
               >
                 My Tickets
               </button>

--- a/client/src/components/MyTickets.tsx
+++ b/client/src/components/MyTickets.tsx
@@ -1,0 +1,411 @@
+import { useEffect, useState, useCallback } from "react";
+import {
+  fetchTickets,
+  fetchCategories,
+  Category,
+  Ticket,
+  TicketListMeta,
+  Priority,
+} from "../api.js";
+import { useRequester } from "../context/RequesterContext.js";
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+type SortField = "createdAt" | "updatedAt";
+type SortOrder = "asc" | "desc";
+type ListState = "loading" | "loaded" | "empty" | "no-results" | "error";
+
+interface MyTicketsProps {
+  onCreateTicket: () => void;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-GB", {
+    day: "2-digit", month: "short", year: "numeric",
+    hour: "2-digit", minute: "2-digit",
+  });
+}
+
+const PRIORITY_BADGE: Record<string, string> = {
+  LOW:    "bg-secondary",
+  MEDIUM: "bg-warning text-dark",
+  HIGH:   "bg-danger",
+};
+const STATUS_BADGE: Record<string, string> = {
+  NEW: "bg-success",
+};
+
+// ── Component ────────────────────────────────────────────────────────────
+
+export function MyTickets({ onCreateTicket }: MyTicketsProps) {
+  const { currentRequester } = useRequester();
+
+  // Filter / sort / pagination state
+  const [search,   setSearch]   = useState("");
+  const [category, setCategory] = useState("");
+  const [priority, setPriority] = useState<Priority | "">("");
+  const [status,   setStatus]   = useState("");
+  const [sort,     setSort]     = useState<SortField>("createdAt");
+  const [order,    setOrder]    = useState<SortOrder>("desc");
+  const [page,     setPage]     = useState(1);
+  const PAGE_SIZE = 10;
+
+  // Data state
+  const [listState,  setListState]  = useState<ListState>("loading");
+  const [tickets,    setTickets]    = useState<Ticket[]>([]);
+  const [meta,       setMeta]       = useState<TicketListMeta | null>(null);
+  const [errorMsg,   setErrorMsg]   = useState<string | null>(null);
+  const [categories, setCategories] = useState<Category[]>([]);
+
+  // Load categories for filter dropdown
+  useEffect(() => {
+    fetchCategories().then(setCategories).catch(() => {});
+  }, []);
+
+  // Load tickets whenever filters/requester change
+  const loadTickets = useCallback(async () => {
+    if (!currentRequester) return;
+    setListState("loading");
+    setErrorMsg(null);
+    try {
+      const result = await fetchTickets({
+        requesterId: currentRequester.id,
+        search:   search   || undefined,
+        category: category || undefined,
+        priority: (priority as Priority) || undefined,
+        status:   status   || undefined,
+        sort, order, page, pageSize: PAGE_SIZE,
+      });
+      setTickets(result.data);
+      setMeta(result.meta);
+      if (result.data.length === 0) {
+        const hasFilters = search || category || priority || status;
+        setListState(hasFilters ? "no-results" : "empty");
+      } else {
+        setListState("loaded");
+      }
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : "Unable to load tickets.");
+      setListState("error");
+    }
+  }, [currentRequester, search, category, priority, status, sort, order, page]);
+
+  useEffect(() => { void loadTickets(); }, [loadTickets]);
+
+  function toggleSort(field: SortField) {
+    if (sort === field) {
+      setOrder(o => o === "asc" ? "desc" : "asc");
+    } else {
+      setSort(field);
+      setOrder("desc");
+    }
+    setPage(1);
+  }
+
+  function clearFilters() {
+    setSearch(""); setCategory(""); setPriority(""); setStatus("");
+    setPage(1);
+  }
+
+  // ── Sort indicator ───────────────────────────────────────────────────
+
+  function SortIcon({ field }: { field: SortField }) {
+    if (sort !== field) return <span style={{ opacity: 0.3 }}> ↕</span>;
+    return <span>{order === "asc" ? " ↑" : " ↓"}</span>;
+  }
+
+  // ── Render ───────────────────────────────────────────────────────────
+
+  return (
+    <div data-testid="my-tickets-screen">
+      {/* ── Page header ── */}
+      <div className="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2">
+        <div>
+          <h1 className="h4 fw-bold mb-0" style={{ color: "#1A2E22" }}>My Tickets</h1>
+          <p className="mb-0 text-muted" style={{ fontSize: "0.875rem" }}>
+            View and track all of your support requests.
+          </p>
+        </div>
+        <div className="d-flex gap-2">
+          <button
+            className="btn btn-outline-secondary btn-sm"
+            onClick={clearFilters}
+            data-testid="clear-filters-btn"
+          >
+            ⟳ Clear Filters
+          </button>
+          <button
+            className="btn text-white btn-sm fw-semibold"
+            style={{ backgroundColor: "#006B3C" }}
+            onClick={onCreateTicket}
+            data-testid="create-ticket-btn"
+          >
+            + Create Ticket
+          </button>
+        </div>
+      </div>
+
+      {/* ── Search + filters ── */}
+      <div className="card shadow-sm border-0 mb-3 p-3">
+        <div className="row g-2">
+          <div className="col-12 col-md-4">
+            <input
+              type="search"
+              className="form-control form-control-sm"
+              placeholder="Search by ticket number or summary…"
+              value={search}
+              onChange={e => { setSearch(e.target.value); setPage(1); }}
+              data-testid="search-input"
+              aria-label="Search tickets"
+            />
+          </div>
+          <div className="col-6 col-md-2">
+            <select
+              className="form-select form-select-sm"
+              value={category}
+              onChange={e => { setCategory(e.target.value); setPage(1); }}
+              data-testid="filter-category"
+              aria-label="Filter by category"
+            >
+              <option value="">All Categories</option>
+              {categories.map(c => (
+                <option key={c.id} value={c.name}>{c.name}</option>
+              ))}
+            </select>
+          </div>
+          <div className="col-6 col-md-2">
+            <select
+              className="form-select form-select-sm"
+              value={priority}
+              onChange={e => { setPriority(e.target.value as Priority | ""); setPage(1); }}
+              data-testid="filter-priority"
+              aria-label="Filter by priority"
+            >
+              <option value="">All Priorities</option>
+              <option value="LOW">Low</option>
+              <option value="MEDIUM">Medium</option>
+              <option value="HIGH">High</option>
+            </select>
+          </div>
+          <div className="col-6 col-md-2">
+            <select
+              className="form-select form-select-sm"
+              value={status}
+              onChange={e => { setStatus(e.target.value); setPage(1); }}
+              data-testid="filter-status"
+              aria-label="Filter by status"
+            >
+              <option value="">All Statuses</option>
+              <option value="NEW">New</option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      {/* ── Loading state ── */}
+      {listState === "loading" && (
+        <div className="text-center py-5" data-testid="tickets-loading">
+          <div className="spinner-border" style={{ color: "#006B3C" }} role="status">
+            <span className="visually-hidden">Loading tickets…</span>
+          </div>
+          <p className="mt-2 text-muted">Loading tickets…</p>
+        </div>
+      )}
+
+      {/* ── Error state ── */}
+      {listState === "error" && (
+        <div className="alert alert-danger d-flex justify-content-between align-items-center"
+          data-testid="tickets-error">
+          <span>{errorMsg ?? "Unable to load tickets. Please try again."}</span>
+          <button className="btn btn-sm btn-outline-danger" onClick={loadTickets}>
+            Retry
+          </button>
+        </div>
+      )}
+
+      {/* ── Empty state (no tickets at all) ── */}
+      {listState === "empty" && (
+        <div className="text-center py-5" data-testid="tickets-empty">
+          <p className="text-muted mb-3" style={{ fontSize: "1rem" }}>
+            You have no tickets yet.
+          </p>
+          <button
+            className="btn text-white"
+            style={{ backgroundColor: "#006B3C" }}
+            onClick={onCreateTicket}
+          >
+            + Create your first ticket
+          </button>
+        </div>
+      )}
+
+      {/* ── No-results state (filters returned nothing) ── */}
+      {listState === "no-results" && (
+        <div className="text-center py-5" data-testid="tickets-no-results">
+          <p className="text-muted mb-3">No tickets match your search or filters.</p>
+          <button className="btn btn-outline-secondary btn-sm" onClick={clearFilters}>
+            Clear Filters
+          </button>
+        </div>
+      )}
+
+      {/* ── Populated table (desktop) / cards (mobile) ── */}
+      {listState === "loaded" && (
+        <>
+          {/* Desktop table */}
+          <div className="d-none d-md-block" data-testid="tickets-table">
+            <div className="card shadow-sm border-0">
+              <div className="table-responsive">
+                <table className="table table-hover mb-0 align-middle">
+                  <thead style={{ backgroundColor: "#F5F7F6" }}>
+                    <tr>
+                      <th scope="col">
+                        <button
+                          className="btn btn-link p-0 text-decoration-none fw-semibold"
+                          style={{ color: "#1A2E22" }}
+                          onClick={() => toggleSort("createdAt")}
+                          aria-label="Sort by created date"
+                        >
+                          Ticket No. / Created <SortIcon field="createdAt" />
+                        </button>
+                      </th>
+                      <th scope="col" style={{ color: "#1A2E22" }}>Summary</th>
+                      <th scope="col" style={{ color: "#1A2E22" }}>Category</th>
+                      <th scope="col" style={{ color: "#1A2E22" }}>Priority</th>
+                      <th scope="col" style={{ color: "#1A2E22" }}>Status</th>
+                      <th scope="col">
+                        <button
+                          className="btn btn-link p-0 text-decoration-none fw-semibold"
+                          style={{ color: "#1A2E22" }}
+                          onClick={() => toggleSort("updatedAt")}
+                          aria-label="Sort by last updated"
+                        >
+                          Last Updated <SortIcon field="updatedAt" />
+                        </button>
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {tickets.map(t => (
+                      <tr key={t.id} data-testid={`ticket-row-${t.ticketNumber}`}>
+                        <td>
+                          <div className="fw-semibold" style={{ color: "#006B3C" }}>
+                            {t.ticketNumber}
+                          </div>
+                          <small className="text-muted">{formatDate(t.createdAt)}</small>
+                        </td>
+                        <td style={{ maxWidth: 280 }}>
+                          <span style={{
+                            display: "block", overflow: "hidden",
+                            textOverflow: "ellipsis", whiteSpace: "nowrap",
+                          }}>
+                            {t.summary}
+                          </span>
+                        </td>
+                        <td>{(t.category as { name: string } | undefined)?.name ?? "—"}</td>
+                        <td>
+                          <span className={`badge ${PRIORITY_BADGE[t.requestedPriority] ?? "bg-secondary"}`}>
+                            {t.requestedPriority}
+                          </span>
+                        </td>
+                        <td>
+                          <span className={`badge ${STATUS_BADGE[t.status] ?? "bg-secondary"}`}>
+                            {t.status}
+                          </span>
+                        </td>
+                        <td><small className="text-muted">{formatDate(t.updatedAt)}</small></td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+
+          {/* Mobile cards */}
+          <div className="d-md-none" data-testid="tickets-cards">
+            {tickets.map(t => (
+              <div
+                key={t.id}
+                className="card shadow-sm border-0 mb-2 p-3"
+                data-testid={`ticket-card-${t.ticketNumber}`}
+              >
+                <div className="d-flex justify-content-between align-items-start">
+                  <span className="fw-semibold" style={{ color: "#006B3C" }}>
+                    {t.ticketNumber}
+                  </span>
+                  <span className={`badge ${STATUS_BADGE[t.status] ?? "bg-secondary"}`}>
+                    {t.status}
+                  </span>
+                </div>
+                <p className="mb-1 mt-1" style={{ fontSize: "0.9rem" }}>{t.summary}</p>
+                <div className="d-flex gap-2 flex-wrap">
+                  <small className="text-muted">
+                    {(t.category as { name: string } | undefined)?.name}
+                  </small>
+                  <span className={`badge ${PRIORITY_BADGE[t.requestedPriority] ?? "bg-secondary"}`}>
+                    {t.requestedPriority}
+                  </span>
+                  <small className="text-muted ms-auto">{formatDate(t.createdAt)}</small>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* ── Pagination ── */}
+          {meta && meta.totalPages > 1 && (
+            <div
+              className="d-flex justify-content-between align-items-center mt-3"
+              data-testid="pagination"
+            >
+              <small className="text-muted">
+                Showing {(page - 1) * PAGE_SIZE + 1}–
+                {Math.min(page * PAGE_SIZE, meta.total)} of {meta.total} tickets
+              </small>
+              <nav aria-label="Ticket list pagination">
+                <ul className="pagination pagination-sm mb-0">
+                  <li className={`page-item ${page === 1 ? "disabled" : ""}`}>
+                    <button
+                      className="page-link"
+                      onClick={() => setPage(p => p - 1)}
+                      disabled={page === 1}
+                      aria-label="Previous page"
+                    >
+                      ‹ Prev
+                    </button>
+                  </li>
+                  {Array.from({ length: meta.totalPages }, (_, i) => i + 1).map(p => (
+                    <li key={p} className={`page-item ${p === page ? "active" : ""}`}>
+                      <button
+                        className="page-link"
+                        onClick={() => setPage(p)}
+                        aria-label={`Go to page ${p}`}
+                        aria-current={p === page ? "page" : undefined}
+                      >
+                        {p}
+                      </button>
+                    </li>
+                  ))}
+                  <li className={`page-item ${page === meta.totalPages ? "disabled" : ""}`}>
+                    <button
+                      className="page-link"
+                      onClick={() => setPage(p => p + 1)}
+                      disabled={page === meta.totalPages}
+                      aria-label="Next page"
+                    >
+                      Next ›
+                    </button>
+                  </li>
+                </ul>
+              </nav>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+export default MyTickets;

--- a/client/tests/lab-01/App.test.tsx
+++ b/client/tests/lab-01/App.test.tsx
@@ -5,110 +5,77 @@ import App from "../../src/App.js";
 import * as api from "../../src/api.js";
 import { RequesterProvider } from "../../src/context/RequesterContext.js";
 
-// App now requires RequesterProvider in its tree (added in Lab 2 Issue 3).
-// We also need a Requester to be pre-selected so App renders the main content
-// instead of the RequesterSelector screen.
-function renderAppWithRequester() {
-  const utils = render(
+// App now shows MyTickets as the default home page (Lab 2 Issue 5).
+// Tests drive past the RequesterSelector first, then verify App behaviour.
+
+const MOCK_REQUESTER = { id: 1, name: "Jennifer Anderson", email: "jennifer@example.com" };
+
+function renderApp() {
+  return render(
     <RequesterProvider>
       <App />
     </RequesterProvider>
   );
-
-  // Simulate a Requester already being selected by completing the selector flow.
-  // The selector screen shows first — we need to drive past it.
-  // Because we are testing App behavior (not the selector), we mock fetchRequesters
-  // and click Continue to set the context before the main assertions run.
-  return utils;
 }
 
 describe("App", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    // fetchRequesters is called by RequesterSelector on mount
-    vi.spyOn(api, "fetchRequesters").mockResolvedValue([
-      { id: 1, name: "Jennifer Anderson", email: "jennifer.anderson@example.com" },
-    ]);
+    vi.spyOn(api, "fetchRequesters").mockResolvedValue([MOCK_REQUESTER]);
+    // MyTickets will call fetchTickets on mount — return empty list by default
+    vi.spyOn(api, "fetchTickets").mockResolvedValue({
+      data: [],
+      meta: { page: 1, pageSize: 10, total: 0, totalPages: 0 },
+    });
+    vi.spyOn(api, "fetchCategories").mockResolvedValue([]);
   });
 
   it("renders the TokTickIT heading and Check System button on load (after requester selection)", async () => {
-    renderAppWithRequester();
+    renderApp();
 
-    // First the selector screen is shown — select a requester and continue
-    await waitFor(() => {
-      expect(screen.getByTestId("requester-select")).toBeInTheDocument();
-    });
+    // Drive past selector
+    await waitFor(() => expect(screen.getByTestId("requester-select")).toBeInTheDocument());
     await userEvent.selectOptions(screen.getByTestId("requester-select"), "1");
     await userEvent.click(screen.getByTestId("selector-continue-btn"));
 
-    // Now the main App content should be visible
+    // App shell and My Tickets screen should be visible
     await waitFor(() => {
-      expect(screen.getByTestId("check-system-btn")).toBeInTheDocument();
+      expect(screen.getByTestId("app-shell-nav")).toBeInTheDocument();
     });
-    expect(screen.getByRole("heading", { name: /TokTickIT/i })).toBeInTheDocument();
+    expect(screen.getByTestId("my-tickets-screen")).toBeInTheDocument();
   });
 
-  it("shows Online status and seeded categories on success", async () => {
-    vi.spyOn(api, "checkSystem").mockResolvedValue({
-      online: true,
-      categories: [
-        { id: 1, name: "Account and Access" },
-        { id: 2, name: "Hardware" },
-        { id: 3, name: "Software" },
-        { id: 4, name: "Network" },
-      ],
-    });
+  it("navigates to Create Ticket when + Create Ticket nav link is clicked", async () => {
+    renderApp();
 
-    renderAppWithRequester();
-
-    // Drive past selector screen
-    await waitFor(() => {
-      expect(screen.getByTestId("requester-select")).toBeInTheDocument();
-    });
+    await waitFor(() => expect(screen.getByTestId("requester-select")).toBeInTheDocument());
     await userEvent.selectOptions(screen.getByTestId("requester-select"), "1");
     await userEvent.click(screen.getByTestId("selector-continue-btn"));
 
-    // Click Check System
-    await waitFor(() => {
-      expect(screen.getByTestId("check-system-btn")).toBeInTheDocument();
-    });
-    await userEvent.click(screen.getByTestId("check-system-btn"));
+    await waitFor(() => expect(screen.getByTestId("nav-create-ticket")).toBeInTheDocument());
+    await userEvent.click(screen.getByTestId("nav-create-ticket"));
+
+    // fetchCategories and fetchRelatedSystems are called by CreateTicket on mount
+    vi.spyOn(api, "fetchRelatedSystems").mockResolvedValue([]);
 
     await waitFor(() => {
-      expect(screen.getByTestId("online-status")).toHaveTextContent("System Status: Online");
+      expect(screen.getByTestId("create-ticket-form")).toBeInTheDocument();
     });
-
-    expect(screen.getByTestId("categories-list")).toBeInTheDocument();
-    expect(screen.getByText("Account and Access")).toBeInTheDocument();
-    expect(screen.getByText("Hardware")).toBeInTheDocument();
-    expect(screen.getByText("Software")).toBeInTheDocument();
-    expect(screen.getByText("Network")).toBeInTheDocument();
   });
 
-  it("shows an Offline error message when the API is unavailable", async () => {
-    vi.spyOn(api, "checkSystem").mockRejectedValue(new Error("Network error"));
+  it("returns to My Tickets when Change Requester is clicked", async () => {
+    renderApp();
 
-    renderAppWithRequester();
-
-    // Drive past selector screen
-    await waitFor(() => {
-      expect(screen.getByTestId("requester-select")).toBeInTheDocument();
-    });
+    await waitFor(() => expect(screen.getByTestId("requester-select")).toBeInTheDocument());
     await userEvent.selectOptions(screen.getByTestId("requester-select"), "1");
     await userEvent.click(screen.getByTestId("selector-continue-btn"));
 
-    // Click Check System
-    await waitFor(() => {
-      expect(screen.getByTestId("check-system-btn")).toBeInTheDocument();
-    });
-    await userEvent.click(screen.getByTestId("check-system-btn"));
+    await waitFor(() => expect(screen.getByTestId("change-requester-btn")).toBeInTheDocument());
+    await userEvent.click(screen.getByTestId("change-requester-btn"));
 
+    // Selector screen should reappear
     await waitFor(() => {
-      expect(screen.getByTestId("offline-status")).toHaveTextContent("System Status: Offline");
+      expect(screen.getByTestId("requester-selector-screen")).toBeInTheDocument();
     });
-
-    expect(screen.getByTestId("health-error-message")).toHaveTextContent(
-      "Unable to connect to TokTickIT API"
-    );
   });
 });

--- a/client/tests/lab-02/MyTickets.test.tsx
+++ b/client/tests/lab-02/MyTickets.test.tsx
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MyTickets } from "../../src/components/MyTickets.js";
+import * as api from "../../src/api.js";
+import { RequesterProvider, useRequester } from "../../src/context/RequesterContext.js";
+
+// ── Constants ─────────────────────────────────────────────────────────────
+
+const MOCK_REQUESTER_A = { id: 1, name: "Jennifer Anderson", email: "jennifer@example.com" };
+const MOCK_REQUESTER_B = { id: 2, name: "Michael Brown",     email: "michael@example.com" };
+
+const makeTicket = (n: number, requesterId = 1) => ({
+  id:               n,
+  ticketNumber:     `TKT-2026-00000${n}`,
+  requesterId,
+  categoryId:       1,
+  relatedSystemId:  1,
+  summary:          `Ticket ${n} summary text here`,
+  description:      `Description for ticket ${n}`,
+  requestedPriority: "MEDIUM" as const,
+  status:           "NEW",
+  ticketDate:       new Date().toISOString(),
+  createdAt:        new Date().toISOString(),
+  updatedAt:        new Date().toISOString(),
+  category:         { id: 1, name: "Hardware" },
+  relatedSystem:    { id: 1, name: "Corporate Laptop" },
+});
+
+const EMPTY_RESPONSE = { data: [], meta: { page: 1, pageSize: 10, total: 0, totalPages: 0 } };
+const THREE_TICKETS   = {
+  data: [makeTicket(1), makeTicket(2), makeTicket(3)],
+  meta: { page: 1, pageSize: 10, total: 3, totalPages: 1 },
+};
+
+// ── Helper ────────────────────────────────────────────────────────────────
+
+function renderMyTickets(
+  requesterId = MOCK_REQUESTER_A,
+  onCreateTicket = vi.fn()
+) {
+  function Seeder() {
+    const { selectRequester, currentRequester } = useRequester();
+    if (!currentRequester) selectRequester(requesterId);
+    return <MyTickets onCreateTicket={onCreateTicket} />;
+  }
+  return render(
+    <RequesterProvider>
+      <Seeder />
+    </RequesterProvider>
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe("MyTickets component", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(api, "fetchCategories").mockResolvedValue([
+      { id: 1, name: "Hardware" },
+      { id: 2, name: "Software" },
+    ]);
+  });
+
+  // ── Loading state ──────────────────────────────────────────────────────
+
+  it("shows a loading state while tickets are being fetched", () => {
+    vi.spyOn(api, "fetchTickets").mockReturnValue(new Promise(() => {}));
+    renderMyTickets();
+    expect(screen.getByTestId("tickets-loading")).toBeInTheDocument();
+  });
+
+  // ── Populated state ────────────────────────────────────────────────────
+
+  it("renders the ticket list when tickets are returned", async () => {
+    vi.spyOn(api, "fetchTickets").mockResolvedValue(THREE_TICKETS);
+    renderMyTickets();
+    await waitFor(() => {
+      expect(screen.getByTestId("tickets-table")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("ticket-row-TKT-2026-000001")).toBeInTheDocument();
+    expect(screen.getByTestId("ticket-row-TKT-2026-000002")).toBeInTheDocument();
+    expect(screen.getByTestId("ticket-row-TKT-2026-000003")).toBeInTheDocument();
+  });
+
+  it("shows ticket summary in the table", async () => {
+    vi.spyOn(api, "fetchTickets").mockResolvedValue(THREE_TICKETS);
+    renderMyTickets();
+    await waitFor(() => expect(screen.getByTestId("tickets-table")).toBeInTheDocument());
+    expect(screen.getAllByText("Ticket 1 summary text here").length).toBeGreaterThan(0);
+  });
+
+  // ── Empty state ────────────────────────────────────────────────────────
+
+  it("shows the empty state when the requester has no tickets", async () => {
+    vi.spyOn(api, "fetchTickets").mockResolvedValue(EMPTY_RESPONSE);
+    renderMyTickets();
+    await waitFor(() => {
+      expect(screen.getByTestId("tickets-empty")).toBeInTheDocument();
+    });
+  });
+
+  it("empty state contains a Create Ticket button", async () => {
+    vi.spyOn(api, "fetchTickets").mockResolvedValue(EMPTY_RESPONSE);
+    renderMyTickets();
+    await waitFor(() => expect(screen.getByTestId("tickets-empty")).toBeInTheDocument());
+    expect(screen.getByText(/create your first ticket/i)).toBeInTheDocument();
+  });
+
+  // ── No-results state ───────────────────────────────────────────────────
+
+  it("shows the no-results state when filters return nothing", async () => {
+    vi.spyOn(api, "fetchTickets").mockResolvedValue(EMPTY_RESPONSE);
+    renderMyTickets();
+
+    // Wait for initial load, then type in search to trigger filters
+    await waitFor(() => expect(screen.getByTestId("tickets-empty")).toBeInTheDocument());
+
+    // Type a search term — now fetchTickets will be called again with a search param
+    // The mock still returns empty, but the component detects filters are active
+    await userEvent.type(screen.getByTestId("search-input"), "nonexistent");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("tickets-no-results")).toBeInTheDocument();
+    });
+  });
+
+  it("no-results state has a Clear Filters button", async () => {
+    vi.spyOn(api, "fetchTickets").mockResolvedValue(EMPTY_RESPONSE);
+    renderMyTickets();
+    await waitFor(() => expect(screen.getByTestId("tickets-empty")).toBeInTheDocument());
+    await userEvent.type(screen.getByTestId("search-input"), "xyz");
+    await waitFor(() => expect(screen.getByTestId("tickets-no-results")).toBeInTheDocument());
+    // Clear Filters button should be present inside no-results area
+    expect(screen.getAllByRole("button", { name: /clear filters/i }).length).toBeGreaterThan(0);
+  });
+
+  // ── Error state ────────────────────────────────────────────────────────
+
+  it("shows an error state when the API call fails", async () => {
+    vi.spyOn(api, "fetchTickets").mockRejectedValue(new Error("Network error"));
+    renderMyTickets();
+    await waitFor(() => {
+      expect(screen.getByTestId("tickets-error")).toBeInTheDocument();
+    });
+  });
+
+  it("error state contains a Retry button", async () => {
+    vi.spyOn(api, "fetchTickets").mockRejectedValue(new Error("Network error"));
+    renderMyTickets();
+    await waitFor(() => expect(screen.getByTestId("tickets-error")).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  // ── Filter controls ────────────────────────────────────────────────────
+
+  it("renders search, category, priority, and status filter controls", async () => {
+    vi.spyOn(api, "fetchTickets").mockResolvedValue(THREE_TICKETS);
+    renderMyTickets();
+    await waitFor(() => expect(screen.getByTestId("tickets-table")).toBeInTheDocument());
+    expect(screen.getByTestId("search-input")).toBeInTheDocument();
+    expect(screen.getByTestId("filter-category")).toBeInTheDocument();
+    expect(screen.getByTestId("filter-priority")).toBeInTheDocument();
+    expect(screen.getByTestId("filter-status")).toBeInTheDocument();
+  });
+
+  it("Clear Filters button resets search and filters", async () => {
+    vi.spyOn(api, "fetchTickets").mockResolvedValue(EMPTY_RESPONSE);
+    renderMyTickets();
+    await waitFor(() => expect(screen.getByTestId("search-input")).toBeInTheDocument());
+
+    await userEvent.type(screen.getByTestId("search-input"), "something");
+    expect(screen.getByTestId("search-input")).toHaveValue("something");
+
+    await userEvent.click(screen.getByTestId("clear-filters-btn"));
+    expect(screen.getByTestId("search-input")).toHaveValue("");
+  });
+
+  // ── Create Ticket nav ──────────────────────────────────────────────────
+
+  it("calls onCreateTicket when + Create Ticket button is clicked", async () => {
+    const onCreateTicket = vi.fn();
+    vi.spyOn(api, "fetchTickets").mockResolvedValue(EMPTY_RESPONSE);
+    renderMyTickets(MOCK_REQUESTER_A, onCreateTicket);
+    await waitFor(() => expect(screen.getByTestId("create-ticket-btn")).toBeInTheDocument());
+    await userEvent.click(screen.getByTestId("create-ticket-btn"));
+    expect(onCreateTicket).toHaveBeenCalledOnce();
+  });
+
+  // ── Ownership reload ───────────────────────────────────────────────────
+
+  it("reloads tickets when the selected requester changes", async () => {
+    const spy = vi.spyOn(api, "fetchTickets").mockResolvedValue(THREE_TICKETS);
+
+    // Render with Requester A
+    const { unmount } = renderMyTickets(MOCK_REQUESTER_A);
+    await waitFor(() => expect(screen.getByTestId("tickets-table")).toBeInTheDocument());
+
+    const callsWithA = spy.mock.calls.filter(
+      c => c[0].requesterId === MOCK_REQUESTER_A.id
+    ).length;
+    expect(callsWithA).toBeGreaterThan(0);
+
+    unmount();
+
+    // Render with Requester B — a fresh component for a different requester
+    spy.mockResolvedValue({
+      data: [makeTicket(10, MOCK_REQUESTER_B.id)],
+      meta: { page: 1, pageSize: 10, total: 1, totalPages: 1 },
+    });
+    renderMyTickets(MOCK_REQUESTER_B);
+    await waitFor(() => expect(screen.getByTestId("tickets-table")).toBeInTheDocument());
+
+    const callsWithB = spy.mock.calls.filter(
+      c => c[0].requesterId === MOCK_REQUESTER_B.id
+    ).length;
+    expect(callsWithB).toBeGreaterThan(0);
+  });
+
+  // ── Pagination ─────────────────────────────────────────────────────────
+
+  it("shows pagination when there are multiple pages", async () => {
+    vi.spyOn(api, "fetchTickets").mockResolvedValue({
+      data: Array.from({ length: 10 }, (_, i) => makeTicket(i + 1)),
+      meta: { page: 1, pageSize: 10, total: 25, totalPages: 3 },
+    });
+    renderMyTickets();
+    await waitFor(() => {
+      expect(screen.getByTestId("pagination")).toBeInTheDocument();
+    });
+  });
+
+  it("does not show pagination when there is only one page", async () => {
+    vi.spyOn(api, "fetchTickets").mockResolvedValue(THREE_TICKETS);
+    renderMyTickets();
+    await waitFor(() => expect(screen.getByTestId("tickets-table")).toBeInTheDocument());
+    expect(screen.queryByTestId("pagination")).not.toBeInTheDocument();
+  });
+});

--- a/server/src/controllers/tickets.controller.ts
+++ b/server/src/controllers/tickets.controller.ts
@@ -5,6 +5,11 @@ import { generateTicketNumber } from "../utils/ticketNumber.js";
 const VALID_PRIORITIES = ["LOW", "MEDIUM", "HIGH"] as const;
 type Priority = typeof VALID_PRIORITIES[number];
 
+const VALID_SORT_FIELDS  = ["createdAt", "updatedAt"] as const;
+const VALID_SORT_ORDERS  = ["asc", "desc"]            as const;
+const ALLOWED_PAGE_SIZES = [10, 25, 50]               as const;
+const DEFAULT_PAGE_SIZE  = 10;
+
 interface CreateTicketBody {
   requesterId?: unknown;
   categoryId?: unknown;
@@ -14,12 +19,175 @@ interface CreateTicketBody {
   requestedPriority?: unknown;
 }
 
+// ── GET /api/tickets ────────────────────────────────────────────────────────
+
 /**
- * POST /api/tickets
- * Creates a new Ticket for the specified Development Requester.
- * Ticket Number and ticketDate are generated server-side.
- * Default status is NEW.
+ * GET /api/tickets
+ * Returns a paginated list of tickets owned by the specified Requester.
+ * Supports: search (ticketNumber + summary), category/priority/status filters,
+ * sort field/direction, page number, and page size.
+ * Ownership is enforced — only tickets belonging to requesterId are returned.
  */
+export const getTickets = async (req: Request, res: Response): Promise<void> => {
+  const prisma = getPrisma();
+
+  // ── Parse + validate requesterId ──────────────────────────────────────
+  const requesterId = Number(req.query.requesterId);
+  if (!req.query.requesterId || isNaN(requesterId)) {
+    res.status(400).json({
+      error: { code: "VALIDATION_ERROR", message: "requesterId query parameter is required." },
+    });
+    return;
+  }
+
+  // Verify requester exists and is active
+  const requester = await prisma.requesterUser.findFirst({
+    where: { id: requesterId, isActive: true },
+  });
+  if (!requester) {
+    res.status(400).json({
+      error: { code: "INVALID_REQUESTER", message: "Requester not found or is inactive." },
+    });
+    return;
+  }
+
+  // ── Parse optional query params ───────────────────────────────────────
+  const search   = typeof req.query.search   === "string" ? req.query.search.trim()   : undefined;
+  const category = typeof req.query.category === "string" ? req.query.category.trim() : undefined;
+
+  const priorityRaw  = typeof req.query.priority === "string" ? req.query.priority.toUpperCase() : undefined;
+  const priority     = priorityRaw && VALID_PRIORITIES.includes(priorityRaw as Priority)
+    ? (priorityRaw as Priority) : undefined;
+  if (priorityRaw && !priority) {
+    res.status(400).json({
+      error: { code: "VALIDATION_ERROR", message: `Invalid priority value: ${req.query.priority}` },
+    });
+    return;
+  }
+
+  const statusRaw = typeof req.query.status === "string" ? req.query.status.toUpperCase() : undefined;
+  if (statusRaw && statusRaw !== "NEW") {
+    res.status(400).json({
+      error: { code: "VALIDATION_ERROR", message: `Invalid status value: ${req.query.status}` },
+    });
+    return;
+  }
+
+  const sortRaw  = typeof req.query.sort  === "string" ? req.query.sort  : "createdAt";
+  const orderRaw = typeof req.query.order === "string" ? req.query.order : "desc";
+  const sort  = VALID_SORT_FIELDS.includes(sortRaw  as typeof VALID_SORT_FIELDS[number])
+    ? sortRaw as typeof VALID_SORT_FIELDS[number] : "createdAt";
+  const order = VALID_SORT_ORDERS.includes(orderRaw as typeof VALID_SORT_ORDERS[number])
+    ? orderRaw as typeof VALID_SORT_ORDERS[number] : "desc";
+
+  const page     = Math.max(1, parseInt(String(req.query.page     ?? "1"),  10) || 1);
+  const pageSizeRaw = parseInt(String(req.query.pageSize ?? String(DEFAULT_PAGE_SIZE)), 10);
+  const pageSize = (ALLOWED_PAGE_SIZES as readonly number[]).includes(pageSizeRaw)
+    ? pageSizeRaw : DEFAULT_PAGE_SIZE;
+
+  // ── Build Prisma where clause ─────────────────────────────────────────
+  const where: Record<string, unknown> = { requesterId };
+
+  if (search) {
+    where.OR = [
+      { ticketNumber: { contains: search, mode: "insensitive" } },
+      { summary:      { contains: search, mode: "insensitive" } },
+    ];
+  }
+  if (category)  where.category      = { name: { equals: category, mode: "insensitive" } };
+  if (priority)  where.requestedPriority = priority;
+  if (statusRaw) where.status            = statusRaw;
+
+  try {
+    const [total, tickets] = await Promise.all([
+      prisma.ticket.count({ where }),
+      prisma.ticket.findMany({
+        where,
+        orderBy: { [sort]: order },
+        skip:  (page - 1) * pageSize,
+        take:  pageSize,
+        include: {
+          category:      { select: { id: true, name: true } },
+          relatedSystem: { select: { id: true, name: true } },
+        },
+      }),
+    ]);
+
+    res.status(200).json({
+      data: tickets,
+      meta: {
+        page,
+        pageSize,
+        total,
+        totalPages: Math.ceil(total / pageSize),
+      },
+    });
+  } catch (err) {
+    console.error("Failed to fetch tickets:", err);
+    res.status(500).json({
+      error: { code: "SERVER_ERROR", message: "Unable to load tickets. Please try again later." },
+    });
+  }
+};
+
+// ── GET /api/tickets/:ticketNumber ──────────────────────────────────────────
+
+/**
+ * GET /api/tickets/:ticketNumber
+ * Returns a single ticket with attachments, enforcing ownership via requesterId query param.
+ * Returns 403 if the ticket exists but belongs to a different Requester.
+ */
+export const getTicketByNumber = async (req: Request, res: Response): Promise<void> => {
+  const prisma = getPrisma();
+  const { ticketNumber } = req.params;
+
+  const requesterId = Number(req.query.requesterId);
+  if (!req.query.requesterId || isNaN(requesterId)) {
+    res.status(400).json({
+      error: { code: "VALIDATION_ERROR", message: "requesterId query parameter is required." },
+    });
+    return;
+  }
+
+  try {
+    const ticket = await prisma.ticket.findUnique({
+      where: { ticketNumber },
+      include: {
+        requester:     { select: { id: true, name: true } },
+        category:      { select: { id: true, name: true } },
+        relatedSystem: { select: { id: true, name: true } },
+        attachments: {
+          orderBy: { uploadedAt: "asc" },
+          select: {
+            id: true, originalName: true, mimeType: true,
+            sizeBytes: true, uploadedAt: true, removedAt: true, removalReason: true,
+          },
+        },
+      },
+    });
+
+    if (!ticket) {
+      res.status(404).json({ error: { code: "NOT_FOUND", message: "Ticket not found." } });
+      return;
+    }
+    if (ticket.requesterId !== requesterId) {
+      res.status(403).json({
+        error: { code: "FORBIDDEN", message: "You do not own this ticket." },
+      });
+      return;
+    }
+
+    res.status(200).json(ticket);
+  } catch (err) {
+    console.error("Failed to fetch ticket:", err);
+    res.status(500).json({
+      error: { code: "SERVER_ERROR", message: "Unable to load ticket. Please try again later." },
+    });
+  }
+};
+
+// ── POST /api/tickets ───────────────────────────────────────────────────────
+
 export const createTicket = async (req: Request, res: Response): Promise<void> => {
   const prisma = getPrisma();
   const body = req.body as CreateTicketBody;

--- a/server/src/routes/tickets.router.ts
+++ b/server/src/routes/tickets.router.ts
@@ -1,7 +1,11 @@
 import { Router, Request, Response, NextFunction } from "express";
 import multer from "multer";
 import path from "path";
-import { createTicket } from "../controllers/tickets.controller.js";
+import {
+  createTicket,
+  getTickets,
+  getTicketByNumber,
+} from "../controllers/tickets.controller.js";
 import { uploadAttachment } from "../controllers/attachments.controller.js";
 
 // Store uploaded files in server/uploads/ with a unique name
@@ -22,6 +26,12 @@ const upload = multer({
 });
 
 const router = Router();
+
+// GET /api/tickets — list tickets for a Requester (search/filter/sort/pagination)
+router.get("/", getTickets);
+
+// GET /api/tickets/:ticketNumber — get one owned Ticket with attachments
+router.get("/:ticketNumber", getTicketByNumber);
 
 // POST /api/tickets — create a new ticket (JSON body, no file)
 router.post("/", createTicket);

--- a/server/tests/lab-02/my-tickets.api.test.ts
+++ b/server/tests/lab-02/my-tickets.api.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import { app } from "../../src/app.js";
+
+// ── Shared mock data ──────────────────────────────────────────────────────
+
+const REQUESTER_A = { id: 1, name: "Jennifer Anderson", isActive: true };
+const REQUESTER_B = { id: 2, name: "Michael Brown",     isActive: true };
+
+const makeTicket = (n: number, requesterId = 1) => ({
+  id:               n,
+  ticketNumber:     `TKT-2026-00000${n}`,
+  requesterId,
+  categoryId:       1,
+  relatedSystemId:  1,
+  summary:          `Ticket ${n} summary`,
+  description:      `Description for ticket ${n}`,
+  requestedPriority: "MEDIUM",
+  status:           "NEW",
+  ticketDate:       new Date().toISOString(),
+  createdAt:        new Date().toISOString(),
+  updatedAt:        new Date().toISOString(),
+  category:         { id: 1, name: "Hardware" },
+  relatedSystem:    { id: 1, name: "Corporate Laptop" },
+});
+
+const TICKETS_A = [makeTicket(1), makeTicket(2), makeTicket(3)];
+const TICKET_A1_FULL = {
+  ...makeTicket(1),
+  requester:   { id: 1, name: "Jennifer Anderson" },
+  attachments: [],
+};
+
+// ── Prisma mock ───────────────────────────────────────────────────────────
+
+const mockFindMany  = vi.fn();
+const mockCount     = vi.fn();
+const mockFindFirst = vi.fn();
+const mockFindUnique = vi.fn();
+
+vi.mock("../../src/prisma.js", () => ({
+  getPrisma: () => ({
+    requesterUser: { findFirst: mockFindFirst },
+    ticket:        { findMany: mockFindMany, count: mockCount, findUnique: mockFindUnique },
+    attachment:    { count: vi.fn().mockResolvedValue(0), create: vi.fn() },
+    category:      { findUnique: vi.fn() },
+    relatedSystem: { findFirst: vi.fn() },
+  }),
+}));
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe("GET /api/tickets", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindFirst.mockResolvedValue(REQUESTER_A);
+    mockFindMany.mockResolvedValue(TICKETS_A);
+    mockCount.mockResolvedValue(3);
+  });
+
+  // Happy path
+  it("returns 200 with data array and meta object", async () => {
+    const res = await request(app).get("/api/tickets?requesterId=1");
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body.meta).toHaveProperty("page");
+    expect(res.body.meta).toHaveProperty("pageSize");
+    expect(res.body.meta).toHaveProperty("total");
+    expect(res.body.meta).toHaveProperty("totalPages");
+  });
+
+  it("defaults to page 1, pageSize 10, sort createdAt desc", async () => {
+    const res = await request(app).get("/api/tickets?requesterId=1");
+    expect(res.status).toBe(200);
+    expect(res.body.meta.page).toBe(1);
+    expect(res.body.meta.pageSize).toBe(10);
+  });
+
+  it("returns correct total and totalPages in meta", async () => {
+    mockCount.mockResolvedValue(3);
+    const res = await request(app).get("/api/tickets?requesterId=1");
+    expect(res.body.meta.total).toBe(3);
+    expect(res.body.meta.totalPages).toBe(1);
+  });
+
+  it("returns empty data array when requester has no tickets", async () => {
+    mockFindMany.mockResolvedValue([]);
+    mockCount.mockResolvedValue(0);
+    const res = await request(app).get("/api/tickets?requesterId=1");
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(0);
+    expect(res.body.meta.total).toBe(0);
+  });
+
+  // Validation
+  it("returns 400 when requesterId is missing", async () => {
+    const res = await request(app).get("/api/tickets");
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 400 for invalid priority filter", async () => {
+    const res = await request(app).get("/api/tickets?requesterId=1&priority=URGENT");
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid status filter", async () => {
+    const res = await request(app).get("/api/tickets?requesterId=1&status=CLOSED");
+    expect(res.status).toBe(400);
+  });
+
+  // Pagination
+  it("respects page and pageSize parameters", async () => {
+    mockCount.mockResolvedValue(25);
+    mockFindMany.mockResolvedValue([makeTicket(11), makeTicket(12)]);
+    const res = await request(app).get("/api/tickets?requesterId=1&page=2&pageSize=10");
+    expect(res.status).toBe(200);
+    expect(res.body.meta.page).toBe(2);
+    expect(res.body.meta.pageSize).toBe(10);
+    expect(res.body.meta.total).toBe(25);
+    expect(res.body.meta.totalPages).toBe(3);
+  });
+
+  it("falls back to pageSize 10 for invalid pageSize values", async () => {
+    const res = await request(app).get("/api/tickets?requesterId=1&pageSize=99");
+    expect(res.status).toBe(200);
+    expect(res.body.meta.pageSize).toBe(10);
+  });
+
+  // Search passes through to DB (we verify the call structure via mock)
+  it("returns 200 when search param is provided", async () => {
+    const res = await request(app).get("/api/tickets?requesterId=1&search=laptop");
+    expect(res.status).toBe(200);
+  });
+
+  // Ownership isolation
+  it("returns 400 when requesterId references an inactive or missing requester", async () => {
+    mockFindFirst.mockResolvedValue(null); // inactive / not found
+    const res = await request(app).get("/api/tickets?requesterId=99");
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("INVALID_REQUESTER");
+  });
+});
+
+describe("GET /api/tickets/:ticketNumber", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindUnique.mockResolvedValue(TICKET_A1_FULL);
+  });
+
+  it("returns 200 with full ticket when requester owns it", async () => {
+    const res = await request(app).get("/api/tickets/TKT-2026-000001?requesterId=1");
+    expect(res.status).toBe(200);
+    expect(res.body.ticketNumber).toBe("TKT-2026-000001");
+    expect(res.body).toHaveProperty("attachments");
+  });
+
+  it("returns 403 when a different requester tries to access the ticket", async () => {
+    // Ticket belongs to requesterId 1, but we request as requesterId 2
+    const res = await request(app).get("/api/tickets/TKT-2026-000001?requesterId=2");
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 404 when ticket does not exist", async () => {
+    mockFindUnique.mockResolvedValue(null);
+    const res = await request(app).get("/api/tickets/TKT-9999-999999?requesterId=1");
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when requesterId is missing", async () => {
+    const res = await request(app).get("/api/tickets/TKT-2026-000001");
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
Summary
- Adds a "My Tickets" page and makes it the default landing view, replacing the old system-status home screen.

Changes
- Add `MyTickets` component and import it into `App.jsx`
- Change default `page` state from `"home"` to `"my_tickets"`
- Update `Page` type to `"my_tickets" | "create_ticket"` (drop `"home"`)
- Remove the old home page UI, including:
- The "Check System" button and `handleCheck` status-check logic
- Loading / success / error states for system status
- The supported request categories list
- The online/offline status badges
- Remove now-unused `checkSystem` and `Category` imports/state
- Keep the existing "Create Ticket" page flow unchanged

