### PR TITLE
feature/lab2-ticket-detail

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,12 +4,16 @@ import { RequesterSelector } from "./components/RequesterSelector.js";
 import { AppShell } from "./components/AppShell.js";
 import { MyTickets } from "./components/MyTickets.js";
 import { CreateTicket } from "./components/CreateTicket.js";
+import { TicketDetail } from "./components/TicketDetail.js";
 
-type Page = "my-tickets" | "create-ticket";
+type Page =
+  | { name: "my-tickets" }
+  | { name: "create-ticket" }
+  | { name: "ticket-detail"; ticketNumber: string };
 
 export default function App() {
   const { currentRequester } = useRequester();
-  const [page, setPage] = useState<Page>("my-tickets");
+  const [page, setPage] = useState<Page>({ name: "my-tickets" });
 
   // Gate: no requester selected → show selector screen
   if (!currentRequester) {
@@ -17,11 +21,24 @@ export default function App() {
   }
 
   return (
-    <AppShell activePage={page} onNavigate={setPage}>
-      {page === "create-ticket" ? (
-        <CreateTicket onCancel={() => setPage("my-tickets")} />
+    <AppShell
+      activePage={page.name === "ticket-detail" ? "my-tickets" : page.name}
+      onNavigate={(p) => setPage({ name: p })}
+    >
+      {page.name === "create-ticket" ? (
+        <CreateTicket onCancel={() => setPage({ name: "my-tickets" })} />
+      ) : page.name === "ticket-detail" ? (
+        <TicketDetail
+          ticketNumber={page.ticketNumber}
+          onBack={() => setPage({ name: "my-tickets" })}
+        />
       ) : (
-        <MyTickets onCreateTicket={() => setPage("create-ticket")} />
+        <MyTickets
+          onCreateTicket={() => setPage({ name: "create-ticket" })}
+          onOpenTicket={(ticketNumber) =>
+            setPage({ name: "ticket-detail", ticketNumber })
+          }
+        />
       )}
     </AppShell>
   );

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -224,3 +224,36 @@ export async function uploadAttachment(
   }
   return response.json();
 }
+
+/**
+ * PATCH /api/attachments/:id/remove — soft-removes an attachment.
+ * Requires a removalReason of at least 5 characters.
+ */
+export async function removeAttachment(
+  attachmentId: number,
+  requesterId: number,
+  removalReason: string
+): Promise<AttachmentMeta> {
+  const response = await fetch(`${API_URL}/api/attachments/${attachmentId}/remove`, {
+    method:  "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body:    JSON.stringify({ requesterId, removalReason }),
+  });
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}));
+    throw new Error(body?.error?.message ?? `Remove failed: ${response.status}`);
+  }
+  return response.json();
+}
+
+/**
+ * Returns the URL to download an active attachment.
+ * The browser navigates to this URL — no fetch needed.
+ * Blocked by the backend (410) if the attachment has been soft-removed.
+ */
+export function getAttachmentDownloadUrl(
+  attachmentId: number,
+  requesterId: number
+): string {
+  return `${API_URL}/api/attachments/${attachmentId}/download?requesterId=${requesterId}`;
+}

--- a/client/src/components/MyTickets.tsx
+++ b/client/src/components/MyTickets.tsx
@@ -17,6 +17,7 @@ type ListState = "loading" | "loaded" | "empty" | "no-results" | "error";
 
 interface MyTicketsProps {
   onCreateTicket: () => void;
+  onOpenTicket:   (ticketNumber: string) => void;
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────
@@ -39,7 +40,7 @@ const STATUS_BADGE: Record<string, string> = {
 
 // ── Component ────────────────────────────────────────────────────────────
 
-export function MyTickets({ onCreateTicket }: MyTicketsProps) {
+export function MyTickets({ onCreateTicket, onOpenTicket }: MyTicketsProps) {
   const { currentRequester } = useRequester();
 
   // Filter / sort / pagination state
@@ -291,10 +292,15 @@ export function MyTickets({ onCreateTicket }: MyTicketsProps) {
                     {tickets.map(t => (
                       <tr key={t.id} data-testid={`ticket-row-${t.ticketNumber}`}>
                         <td>
-                          <div className="fw-semibold" style={{ color: "#006B3C" }}>
+                          <button
+                            className="btn btn-link p-0 fw-semibold text-decoration-none"
+                            style={{ color: "#006B3C" }}
+                            onClick={() => onOpenTicket(t.ticketNumber)}
+                            data-testid={`ticket-link-${t.ticketNumber}`}
+                          >
                             {t.ticketNumber}
-                          </div>
-                          <small className="text-muted">{formatDate(t.createdAt)}</small>
+                          </button>
+                          <small className="d-block text-muted">{formatDate(t.createdAt)}</small>
                         </td>
                         <td style={{ maxWidth: 280 }}>
                           <span style={{
@@ -333,9 +339,14 @@ export function MyTickets({ onCreateTicket }: MyTicketsProps) {
                 data-testid={`ticket-card-${t.ticketNumber}`}
               >
                 <div className="d-flex justify-content-between align-items-start">
-                  <span className="fw-semibold" style={{ color: "#006B3C" }}>
+                  <button
+                    className="btn btn-link p-0 fw-semibold text-decoration-none"
+                    style={{ color: "#006B3C" }}
+                    onClick={() => onOpenTicket(t.ticketNumber)}
+                    data-testid={`ticket-card-link-${t.ticketNumber}`}
+                  >
                     {t.ticketNumber}
-                  </span>
+                  </button>
                   <span className={`badge ${STATUS_BADGE[t.status] ?? "bg-secondary"}`}>
                     {t.status}
                   </span>

--- a/client/src/components/TicketDetail.tsx
+++ b/client/src/components/TicketDetail.tsx
@@ -1,0 +1,567 @@
+import { useEffect, useState, useRef, ChangeEvent } from "react";
+import {
+  fetchTicketByNumber,
+  uploadAttachment,
+  removeAttachment,
+  getAttachmentDownloadUrl,
+  Ticket,
+  AttachmentMeta,
+} from "../api.js";
+import { useRequester } from "../context/RequesterContext.js";
+
+// ── Constants ────────────────────────────────────────────────────────────
+
+const ALLOWED_TYPES  = ["image/jpeg", "image/jpg", "image/png", "image/webp", "application/pdf"];
+const MAX_SIZE_BYTES = 5 * 1024 * 1024;
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-GB", {
+    day: "2-digit", month: "short", year: "numeric",
+    hour: "2-digit", minute: "2-digit",
+  });
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+const PRIORITY_BADGE: Record<string, string> = {
+  LOW:    "bg-secondary",
+  MEDIUM: "bg-warning text-dark",
+  HIGH:   "bg-danger",
+};
+const STATUS_BADGE: Record<string, string> = {
+  NEW: "bg-success",
+};
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+type DetailState = "loading" | "loaded" | "error";
+
+interface RemoveModalState {
+  attachmentId: number;
+  originalName: string;
+  reason: string;
+  error: string | null;
+  submitting: boolean;
+}
+
+interface TicketDetailProps {
+  ticketNumber: string;
+  onBack: () => void;
+}
+
+// ── Read-only field ───────────────────────────────────────────────────────
+
+function ReadOnlyField({
+  label,
+  value,
+  testId,
+}: {
+  label: string;
+  value: string | undefined;
+  testId?: string;
+}) {
+  return (
+    <div>
+      <label
+        className="form-label fw-semibold mb-1"
+        style={{ color: "#1A2E22", fontSize: "0.875rem" }}
+      >
+        {label}
+      </label>
+      <div
+        className="form-control-plaintext ps-2 rounded"
+        style={{ backgroundColor: "#F0F4F2", color: "#1A2E22", minHeight: 38 }}
+        data-testid={testId}
+      >
+        {value ?? "—"}
+      </div>
+    </div>
+  );
+}
+
+// ── Component ────────────────────────────────────────────────────────────
+
+export function TicketDetail({ ticketNumber, onBack }: TicketDetailProps) {
+  const { currentRequester } = useRequester();
+
+  const [detailState, setDetailState] = useState<DetailState>("loading");
+  const [ticket,      setTicket]      = useState<Ticket | null>(null);
+  const [attachments, setAttachments] = useState<AttachmentMeta[]>([]);
+  const [errorMsg,    setErrorMsg]    = useState<string | null>(null);
+
+  // Upload state
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploadError,    setUploadError]    = useState<string | null>(null);
+  const [uploadingFile,  setUploadingFile]  = useState<string | null>(null); // filename while uploading
+
+  // Remove modal state
+  const [removeModal, setRemoveModal] = useState<RemoveModalState | null>(null);
+
+  // ── Load ticket ────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    if (!currentRequester) return;
+    setDetailState("loading");
+    fetchTicketByNumber(ticketNumber, currentRequester.id)
+      .then((t) => {
+        setTicket(t);
+        setAttachments((t as Ticket & { attachments?: AttachmentMeta[] }).attachments ?? []);
+        setDetailState("loaded");
+      })
+      .catch((err: Error) => {
+        setErrorMsg(err.message);
+        setDetailState("error");
+      });
+  }, [ticketNumber, currentRequester]);
+
+  // ── Upload ─────────────────────────────────────────────────────────────
+
+  async function handleFileChange(e: ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file || !ticket || !currentRequester) return;
+    if (fileInputRef.current) fileInputRef.current.value = "";
+
+    setUploadError(null);
+
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      setUploadError(`"${file.name}" is not an allowed type. Use JPG, PNG, WEBP, or PDF.`);
+      return;
+    }
+    if (file.size > MAX_SIZE_BYTES) {
+      setUploadError(`"${file.name}" exceeds the 5 MB size limit.`);
+      return;
+    }
+
+    setUploadingFile(file.name);
+    try {
+      const meta = await uploadAttachment(ticketNumber, currentRequester.id, file);
+      setAttachments((prev) => [...prev, meta]);
+    } catch (err) {
+      setUploadError(
+        err instanceof Error ? err.message : "Upload failed. Please try again."
+      );
+    } finally {
+      setUploadingFile(null);
+    }
+  }
+
+  // ── Remove modal ───────────────────────────────────────────────────────
+
+  function openRemoveModal(att: AttachmentMeta) {
+    setRemoveModal({
+      attachmentId: att.id,
+      originalName: att.originalName,
+      reason:       "",
+      error:        null,
+      submitting:   false,
+    });
+  }
+
+  function closeRemoveModal() {
+    setRemoveModal(null);
+  }
+
+  async function confirmRemove() {
+    if (!removeModal || !currentRequester) return;
+    if (removeModal.reason.trim().length < 5) {
+      setRemoveModal((m) => m ? { ...m, error: "Reason must be at least 5 characters." } : m);
+      return;
+    }
+    setRemoveModal((m) => m ? { ...m, submitting: true, error: null } : m);
+    try {
+      const updated = await removeAttachment(
+        removeModal.attachmentId,
+        currentRequester.id,
+        removeModal.reason.trim()
+      );
+      setAttachments((prev) =>
+        prev.map((a) => (a.id === updated.id ? updated : a))
+      );
+      closeRemoveModal();
+    } catch (err) {
+      setRemoveModal((m) =>
+        m ? {
+          ...m,
+          submitting: false,
+          error: err instanceof Error ? err.message : "Remove failed.",
+        } : m
+      );
+    }
+  }
+
+  // ── Render states ──────────────────────────────────────────────────────
+
+  if (detailState === "loading") {
+    return (
+      <div className="text-center py-5" data-testid="ticket-detail-loading">
+        <div className="spinner-border" style={{ color: "#006B3C" }} role="status">
+          <span className="visually-hidden">Loading ticket…</span>
+        </div>
+        <p className="mt-2 text-muted">Loading ticket…</p>
+      </div>
+    );
+  }
+
+  if (detailState === "error" || !ticket) {
+    return (
+      <div data-testid="ticket-detail-error">
+        <div className="alert alert-danger">
+          {errorMsg ?? "Unable to load ticket."}
+        </div>
+        <button className="btn btn-outline-secondary btn-sm" onClick={onBack}>
+          ← Back to My Tickets
+        </button>
+      </div>
+    );
+  }
+
+  // ── Main render ────────────────────────────────────────────────────────
+
+  const t = ticket as Ticket & {
+    requester?:     { id: number; name: string };
+    category?:      { id: number; name: string };
+    relatedSystem?: { id: number; name: string };
+  };
+
+  const activeAttachments  = attachments.filter((a) => a.removedAt === null);
+  const removedAttachments = attachments.filter((a) => a.removedAt !== null);
+
+  return (
+    <div data-testid="ticket-detail-screen">
+      {/* ── Breadcrumb + back ── */}
+      <nav aria-label="breadcrumb" className="mb-3">
+        <ol className="breadcrumb mb-0" style={{ fontSize: "0.875rem" }}>
+          <li className="breadcrumb-item">
+            <button
+              className="btn btn-link p-0 text-decoration-none"
+              style={{ color: "#0B7A46" }}
+              onClick={onBack}
+              data-testid="back-to-tickets-btn"
+            >
+              My Tickets
+            </button>
+          </li>
+          <li className="breadcrumb-item active" aria-current="page">
+            {t.ticketNumber}
+          </li>
+        </ol>
+      </nav>
+
+      <div className="card shadow-sm border-0 p-4 mb-4" data-testid="ticket-header">
+        {/* ── Row 1: Ticket No. + Date ── */}
+        <div className="row g-3 mb-3">
+          <div className="col-md-6">
+            <ReadOnlyField label="Ticket No." value={t.ticketNumber} testId="detail-ticket-number" />
+          </div>
+          <div className="col-md-6">
+            <ReadOnlyField label="Ticket Date" value={formatDate(t.ticketDate)} testId="detail-ticket-date" />
+          </div>
+        </div>
+
+        {/* ── Row 2: Requester + Priority ── */}
+        <div className="row g-3 mb-3">
+          <div className="col-md-6">
+            <ReadOnlyField label="Requester" value={t.requester?.name} testId="detail-requester" />
+          </div>
+          <div className="col-md-6">
+            <div>
+              <label className="form-label fw-semibold mb-1" style={{ color: "#1A2E22", fontSize: "0.875rem" }}>
+                Requested Priority
+              </label>
+              <div className="ps-1 pt-1" data-testid="detail-priority">
+                <span className={`badge ${PRIORITY_BADGE[t.requestedPriority] ?? "bg-secondary"}`}>
+                  {t.requestedPriority}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* ── Row 3: Category + Related System ── */}
+        <div className="row g-3 mb-3">
+          <div className="col-md-6">
+            <ReadOnlyField label="Category" value={t.category?.name} testId="detail-category" />
+          </div>
+          <div className="col-md-6">
+            <ReadOnlyField label="Related System" value={t.relatedSystem?.name} testId="detail-related-system" />
+          </div>
+        </div>
+
+        {/* ── Row 4: Status ── */}
+        <div className="row g-3 mb-3">
+          <div className="col-md-6">
+            <div>
+              <label className="form-label fw-semibold mb-1" style={{ color: "#1A2E22", fontSize: "0.875rem" }}>
+                Current Status
+              </label>
+              <div className="ps-1 pt-1" data-testid="detail-status">
+                <span className={`badge ${STATUS_BADGE[t.status] ?? "bg-secondary"}`}>
+                  {t.status}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* ── Summary ── */}
+        <div className="mb-3">
+          <ReadOnlyField label="Ticket Summary" value={t.summary} testId="detail-summary" />
+        </div>
+
+        {/* ── Description ── */}
+        <div>
+          <label className="form-label fw-semibold mb-1" style={{ color: "#1A2E22", fontSize: "0.875rem" }}>
+            Description
+          </label>
+          <div
+            className="rounded p-2"
+            style={{
+              backgroundColor: "#F0F4F2", color: "#1A2E22",
+              whiteSpace: "pre-wrap", minHeight: 80,
+            }}
+            data-testid="detail-description"
+          >
+            {t.description}
+          </div>
+        </div>
+      </div>
+
+      {/* ── Attachments section ── */}
+      <div className="card shadow-sm border-0 p-4" data-testid="attachments-section">
+        <div className="d-flex justify-content-between align-items-center mb-3">
+          <h2 className="h6 fw-bold mb-0" style={{ color: "#1A2E22" }}>
+            Attachments
+            {activeAttachments.length > 0 && (
+              <span className="badge bg-secondary ms-2">{activeAttachments.length}</span>
+            )}
+          </h2>
+
+          {/* Add attachment control */}
+          <div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              className="d-none"
+              onChange={handleFileChange}
+              disabled={!!uploadingFile}
+              data-testid="add-attachment-input"
+              aria-label="Add attachment"
+            />
+            <button
+              type="button"
+              className="btn btn-sm btn-outline-secondary"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={!!uploadingFile}
+              data-testid="add-attachment-btn"
+            >
+              {uploadingFile ? (
+                <>
+                  <span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true" />
+                  Uploading…
+                </>
+              ) : (
+                "+ Add Attachment"
+              )}
+            </button>
+          </div>
+        </div>
+
+        {/* Upload error */}
+        {uploadError && (
+          <div className="alert alert-danger py-2 mb-3" data-testid="upload-error">
+            {uploadError}
+          </div>
+        )}
+
+        {/* Active attachments */}
+        {activeAttachments.length === 0 && removedAttachments.length === 0 && (
+          <p className="text-muted mb-0" style={{ fontSize: "0.875rem" }} data-testid="no-attachments">
+            No attachments yet.
+          </p>
+        )}
+
+        {activeAttachments.length > 0 && (
+          <ul className="list-group list-group-flush mb-2" data-testid="active-attachments-list">
+            {activeAttachments.map((att) => (
+              <li
+                key={att.id}
+                className="list-group-item d-flex justify-content-between align-items-center px-0"
+                data-testid={`attachment-active-${att.id}`}
+              >
+                <div>
+                  <span className="fw-semibold" style={{ fontSize: "0.9rem" }}>
+                    {att.originalName}
+                  </span>
+                  <small className="text-muted ms-2">
+                    {formatBytes(att.sizeBytes)} · {formatDate(att.uploadedAt)}
+                  </small>
+                </div>
+                <div className="d-flex gap-2">
+                  <a
+                    href={getAttachmentDownloadUrl(att.id, currentRequester!.id)}
+                    className="btn btn-sm btn-outline-secondary"
+                    target="_blank"
+                    rel="noreferrer"
+                    data-testid={`download-btn-${att.id}`}
+                    aria-label={`Download ${att.originalName}`}
+                  >
+                    Download
+                  </a>
+                  <button
+                    type="button"
+                    className="btn btn-sm btn-outline-danger"
+                    onClick={() => openRemoveModal(att)}
+                    data-testid={`remove-btn-${att.id}`}
+                    aria-label={`Remove ${att.originalName}`}
+                  >
+                    Remove
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {/* Removed attachments (metadata only, no download) */}
+        {removedAttachments.length > 0 && (
+          <div data-testid="removed-attachments-list">
+            <p className="text-muted mb-1" style={{ fontSize: "0.8rem" }}>Removed attachments:</p>
+            <ul className="list-group list-group-flush">
+              {removedAttachments.map((att) => (
+                <li
+                  key={att.id}
+                  className="list-group-item px-0"
+                  style={{ opacity: 0.6 }}
+                  data-testid={`attachment-removed-${att.id}`}
+                >
+                  <div className="d-flex justify-content-between align-items-start">
+                    <div>
+                      <span
+                        className="fw-semibold text-decoration-line-through"
+                        style={{ fontSize: "0.9rem", color: "#5A6E62" }}
+                      >
+                        {att.originalName}
+                      </span>
+                      <small className="text-muted ms-2">
+                        {formatBytes(att.sizeBytes)}
+                      </small>
+                      <div style={{ fontSize: "0.8rem", color: "#5A6E62" }}>
+                        Removed {att.removedAt ? formatDate(att.removedAt) : ""} — "{att.removalReason}"
+                      </div>
+                    </div>
+                    {/* No download button for removed attachments */}
+                    <span
+                      className="badge bg-secondary"
+                      data-testid={`removed-badge-${att.id}`}
+                    >
+                      REMOVED
+                    </span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+
+      {/* ── Remove modal ── */}
+      {removeModal && (
+        <div
+          className="modal d-block"
+          style={{ backgroundColor: "rgba(0,0,0,0.4)" }}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="remove-modal-title"
+          data-testid="remove-modal"
+        >
+          <div className="modal-dialog modal-dialog-centered">
+            <div className="modal-content">
+              <div className="modal-header">
+                <h5 className="modal-title" id="remove-modal-title">
+                  Remove Attachment
+                </h5>
+                <button
+                  type="button"
+                  className="btn-close"
+                  onClick={closeRemoveModal}
+                  disabled={removeModal.submitting}
+                  aria-label="Close"
+                />
+              </div>
+              <div className="modal-body">
+                <p className="mb-3">
+                  Are you sure you want to remove{" "}
+                  <strong>{removeModal.originalName}</strong>? This cannot be undone.
+                </p>
+                <label
+                  htmlFor="removal-reason"
+                  className="form-label fw-semibold"
+                  style={{ fontSize: "0.875rem" }}
+                >
+                  Reason for removal <span className="text-danger">*</span>
+                </label>
+                <textarea
+                  id="removal-reason"
+                  className="form-control"
+                  rows={3}
+                  value={removeModal.reason}
+                  onChange={(e) =>
+                    setRemoveModal((m) => m ? { ...m, reason: e.target.value } : m)
+                  }
+                  disabled={removeModal.submitting}
+                  placeholder="Minimum 5 characters"
+                  data-testid="removal-reason-input"
+                  aria-required="true"
+                />
+                {removeModal.error && (
+                  <div
+                    className="text-danger mt-1"
+                    style={{ fontSize: "0.82rem" }}
+                    data-testid="removal-reason-error"
+                  >
+                    {removeModal.error}
+                  </div>
+                )}
+              </div>
+              <div className="modal-footer">
+                <button
+                  type="button"
+                  className="btn btn-outline-secondary"
+                  onClick={closeRemoveModal}
+                  disabled={removeModal.submitting}
+                  data-testid="cancel-remove-btn"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-danger"
+                  onClick={confirmRemove}
+                  disabled={removeModal.submitting}
+                  data-testid="confirm-remove-btn"
+                >
+                  {removeModal.submitting ? (
+                    <>
+                      <span className="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true" />
+                      Removing…
+                    </>
+                  ) : (
+                    "Confirm Remove"
+                  )}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default TicketDetail;

--- a/client/tests/lab-01/App.test.tsx
+++ b/client/tests/lab-01/App.test.tsx
@@ -28,6 +28,7 @@ describe("App", () => {
       meta: { page: 1, pageSize: 10, total: 0, totalPages: 0 },
     });
     vi.spyOn(api, "fetchCategories").mockResolvedValue([]);
+    vi.spyOn(api, "fetchRelatedSystems").mockResolvedValue([]);
   });
 
   it("renders the TokTickIT heading and Check System button on load (after requester selection)", async () => {
@@ -54,9 +55,6 @@ describe("App", () => {
 
     await waitFor(() => expect(screen.getByTestId("nav-create-ticket")).toBeInTheDocument());
     await userEvent.click(screen.getByTestId("nav-create-ticket"));
-
-    // fetchCategories and fetchRelatedSystems are called by CreateTicket on mount
-    vi.spyOn(api, "fetchRelatedSystems").mockResolvedValue([]);
 
     await waitFor(() => {
       expect(screen.getByTestId("create-ticket-form")).toBeInTheDocument();

--- a/client/tests/lab-02/MyTickets.test.tsx
+++ b/client/tests/lab-02/MyTickets.test.tsx
@@ -37,12 +37,13 @@ const THREE_TICKETS   = {
 
 function renderMyTickets(
   requesterId = MOCK_REQUESTER_A,
-  onCreateTicket = vi.fn()
+  onCreateTicket = vi.fn(),
+  onOpenTicket = vi.fn()
 ) {
   function Seeder() {
     const { selectRequester, currentRequester } = useRequester();
     if (!currentRequester) selectRequester(requesterId);
-    return <MyTickets onCreateTicket={onCreateTicket} />;
+    return <MyTickets onCreateTicket={onCreateTicket} onOpenTicket={onOpenTicket} />;
   }
   return render(
     <RequesterProvider>
@@ -181,7 +182,7 @@ describe("MyTickets component", () => {
   it("calls onCreateTicket when + Create Ticket button is clicked", async () => {
     const onCreateTicket = vi.fn();
     vi.spyOn(api, "fetchTickets").mockResolvedValue(EMPTY_RESPONSE);
-    renderMyTickets(MOCK_REQUESTER_A, onCreateTicket);
+    renderMyTickets(MOCK_REQUESTER_A, onCreateTicket, vi.fn());
     await waitFor(() => expect(screen.getByTestId("create-ticket-btn")).toBeInTheDocument());
     await userEvent.click(screen.getByTestId("create-ticket-btn"));
     expect(onCreateTicket).toHaveBeenCalledOnce();

--- a/client/tests/lab-02/TicketDetail.test.tsx
+++ b/client/tests/lab-02/TicketDetail.test.tsx
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TicketDetail } from "../../src/components/TicketDetail.js";
+import * as api from "../../src/api.js";
+import { RequesterProvider, useRequester } from "../../src/context/RequesterContext.js";
+
+// ── Constants ─────────────────────────────────────────────────────────────
+
+const MOCK_REQUESTER = { id: 1, name: "Jennifer Anderson", email: "jennifer@example.com" };
+
+const ACTIVE_ATTACHMENT: api.AttachmentMeta = {
+  id:            3,
+  originalName:  "screenshot.png",
+  mimeType:      "image/png",
+  sizeBytes:     204800,
+  uploadedAt:    new Date().toISOString(),
+  removedAt:     null,
+  removalReason: null,
+};
+
+const REMOVED_ATTACHMENT: api.AttachmentMeta = {
+  id:            4,
+  originalName:  "old-report.pdf",
+  mimeType:      "application/pdf",
+  sizeBytes:     512000,
+  uploadedAt:    new Date().toISOString(),
+  removedAt:     new Date().toISOString(),
+  removalReason: "Not relevant to the issue",
+};
+
+const MOCK_TICKET = {
+  id:               1,
+  ticketNumber:     "TKT-2026-000001",
+  requesterId:      1,
+  categoryId:       1,
+  relatedSystemId:  1,
+  summary:          "Laptop battery drains quickly",
+  description:      "Battery drains much faster than usual after last update.",
+  requestedPriority: "MEDIUM" as api.Priority,
+  status:           "NEW",
+  ticketDate:       new Date().toISOString(),
+  createdAt:        new Date().toISOString(),
+  updatedAt:        new Date().toISOString(),
+  requester:        { id: 1, name: "Jennifer Anderson" },
+  category:         { id: 1, name: "Hardware" },
+  relatedSystem:    { id: 1, name: "Corporate Laptop" },
+  attachments:      [ACTIVE_ATTACHMENT, REMOVED_ATTACHMENT],
+};
+
+// ── Helper ────────────────────────────────────────────────────────────────
+
+function renderTicketDetail(onBack = vi.fn()) {
+  function Seeder() {
+    const { selectRequester, currentRequester } = useRequester();
+    if (!currentRequester) selectRequester(MOCK_REQUESTER);
+    return <TicketDetail ticketNumber="TKT-2026-000001" onBack={onBack} />;
+  }
+  return render(
+    <RequesterProvider>
+      <Seeder />
+    </RequesterProvider>
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe("TicketDetail component", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(api, "fetchTicketByNumber").mockResolvedValue(MOCK_TICKET as never);
+  });
+
+  // ── Loading / error states ─────────────────────────────────────────────
+
+  it("shows a loading state while the ticket is being fetched", () => {
+    vi.spyOn(api, "fetchTicketByNumber").mockReturnValue(new Promise(() => {}));
+    renderTicketDetail();
+    expect(screen.getByTestId("ticket-detail-loading")).toBeInTheDocument();
+  });
+
+  it("shows an error state when the API call fails", async () => {
+    vi.spyOn(api, "fetchTicketByNumber").mockRejectedValue(new Error("Not found"));
+    renderTicketDetail();
+    await waitFor(() => {
+      expect(screen.getByTestId("ticket-detail-error")).toBeInTheDocument();
+    });
+  });
+
+  // ── Ticket fields ──────────────────────────────────────────────────────
+
+  it("renders the ticket screen after loading", async () => {
+    renderTicketDetail();
+    await waitFor(() => {
+      expect(screen.getByTestId("ticket-detail-screen")).toBeInTheDocument();
+    });
+  });
+
+  it("displays the ticket number as a read-only field", async () => {
+    renderTicketDetail();
+    await waitFor(() => expect(screen.getByTestId("detail-ticket-number")).toBeInTheDocument());
+    expect(screen.getByTestId("detail-ticket-number")).toHaveTextContent("TKT-2026-000001");
+  });
+
+  it("displays the ticket summary as a read-only field", async () => {
+    renderTicketDetail();
+    await waitFor(() => expect(screen.getByTestId("detail-summary")).toBeInTheDocument());
+    expect(screen.getByTestId("detail-summary")).toHaveTextContent("Laptop battery drains quickly");
+  });
+
+  it("displays the requester name as a read-only field", async () => {
+    renderTicketDetail();
+    await waitFor(() => expect(screen.getByTestId("detail-requester")).toBeInTheDocument());
+    expect(screen.getByTestId("detail-requester")).toHaveTextContent("Jennifer Anderson");
+  });
+
+  // ── Attachment states ──────────────────────────────────────────────────
+
+  it("renders the active attachment with a download button and remove button", async () => {
+    renderTicketDetail();
+    await waitFor(() =>
+      expect(screen.getByTestId("active-attachments-list")).toBeInTheDocument()
+    );
+    expect(screen.getByTestId(`attachment-active-${ACTIVE_ATTACHMENT.id}`)).toBeInTheDocument();
+    expect(screen.getByTestId(`download-btn-${ACTIVE_ATTACHMENT.id}`)).toBeInTheDocument();
+    expect(screen.getByTestId(`remove-btn-${ACTIVE_ATTACHMENT.id}`)).toBeInTheDocument();
+  });
+
+  it("renders the removed attachment with REMOVED badge and no download button", async () => {
+    renderTicketDetail();
+    await waitFor(() =>
+      expect(screen.getByTestId("removed-attachments-list")).toBeInTheDocument()
+    );
+    expect(screen.getByTestId(`attachment-removed-${REMOVED_ATTACHMENT.id}`)).toBeInTheDocument();
+    expect(screen.getByTestId(`removed-badge-${REMOVED_ATTACHMENT.id}`)).toHaveTextContent("REMOVED");
+    expect(screen.queryByTestId(`download-btn-${REMOVED_ATTACHMENT.id}`)).not.toBeInTheDocument();
+  });
+
+  // ── Upload errors ──────────────────────────────────────────────────────
+
+  it("shows an upload error for an unsupported file type", async () => {
+    renderTicketDetail();
+    await waitFor(() => expect(screen.getByTestId("add-attachment-input")).toBeInTheDocument());
+    const badFile = new File(["x"], "malware.exe", { type: "application/octet-stream" });
+    await userEvent.upload(screen.getByTestId("add-attachment-input"), badFile);
+    await waitFor(() => {
+      expect(screen.getByTestId("upload-error")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("upload-error")).toHaveTextContent("not an allowed type");
+  });
+
+  it("shows an upload error for a file that exceeds 5 MB", async () => {
+    renderTicketDetail();
+    await waitFor(() => expect(screen.getByTestId("add-attachment-input")).toBeInTheDocument());
+    const bigFile = new File([new Uint8Array(6 * 1024 * 1024)], "large.jpg", {
+      type: "image/jpeg",
+    });
+    await userEvent.upload(screen.getByTestId("add-attachment-input"), bigFile);
+    await waitFor(() => {
+      expect(screen.getByTestId("upload-error")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("upload-error")).toHaveTextContent("5 MB");
+  });
+
+  // ── Remove modal ───────────────────────────────────────────────────────
+
+  it("opens the remove modal when the Remove button is clicked", async () => {
+    renderTicketDetail();
+    await waitFor(() =>
+      expect(screen.getByTestId(`remove-btn-${ACTIVE_ATTACHMENT.id}`)).toBeInTheDocument()
+    );
+    await userEvent.click(screen.getByTestId(`remove-btn-${ACTIVE_ATTACHMENT.id}`));
+    expect(screen.getByTestId("remove-modal")).toBeInTheDocument();
+  });
+
+  it("shows a validation error when reason is too short", async () => {
+    renderTicketDetail();
+    await waitFor(() =>
+      expect(screen.getByTestId(`remove-btn-${ACTIVE_ATTACHMENT.id}`)).toBeInTheDocument()
+    );
+    await userEvent.click(screen.getByTestId(`remove-btn-${ACTIVE_ATTACHMENT.id}`));
+    await userEvent.type(screen.getByTestId("removal-reason-input"), "nope");
+    await userEvent.click(screen.getByTestId("confirm-remove-btn"));
+    expect(screen.getByTestId("removal-reason-error")).toBeInTheDocument();
+    expect(screen.getByTestId("removal-reason-error")).toHaveTextContent("at least 5 characters");
+  });
+
+  it("calls removeAttachment and closes the modal on a valid reason", async () => {
+    const removedResult: api.AttachmentMeta = {
+      ...ACTIVE_ATTACHMENT,
+      removedAt:     new Date().toISOString(),
+      removalReason: "Valid removal reason",
+    };
+    vi.spyOn(api, "removeAttachment").mockResolvedValue(removedResult);
+
+    renderTicketDetail();
+    await waitFor(() =>
+      expect(screen.getByTestId(`remove-btn-${ACTIVE_ATTACHMENT.id}`)).toBeInTheDocument()
+    );
+    await userEvent.click(screen.getByTestId(`remove-btn-${ACTIVE_ATTACHMENT.id}`));
+    await userEvent.type(screen.getByTestId("removal-reason-input"), "Valid removal reason");
+    await userEvent.click(screen.getByTestId("confirm-remove-btn"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("remove-modal")).not.toBeInTheDocument();
+    });
+    expect(api.removeAttachment).toHaveBeenCalledWith(
+      ACTIVE_ATTACHMENT.id,
+      MOCK_REQUESTER.id,
+      "Valid removal reason"
+    );
+  });
+
+  it("closes the modal without removing when Cancel is clicked", async () => {
+    renderTicketDetail();
+    await waitFor(() =>
+      expect(screen.getByTestId(`remove-btn-${ACTIVE_ATTACHMENT.id}`)).toBeInTheDocument()
+    );
+    await userEvent.click(screen.getByTestId(`remove-btn-${ACTIVE_ATTACHMENT.id}`));
+    expect(screen.getByTestId("remove-modal")).toBeInTheDocument();
+    await userEvent.click(screen.getByTestId("cancel-remove-btn"));
+    expect(screen.queryByTestId("remove-modal")).not.toBeInTheDocument();
+  });
+
+  it("calls onBack when Back to My Tickets is clicked", async () => {
+    const onBack = vi.fn();
+    renderTicketDetail(onBack);
+    await waitFor(() => expect(screen.getByTestId("back-to-tickets-btn")).toBeInTheDocument());
+    await userEvent.click(screen.getByTestId("back-to-tickets-btn"));
+    expect(onBack).toHaveBeenCalledOnce();
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -5,9 +5,8 @@ import categoriesRouter from "./routes/categories.router.js";
 import requestersRouter from "./routes/requesters.router.js";
 import relatedSystemsRouter from "./routes/relatedSystems.router.js";
 import ticketsRouter from "./routes/tickets.router.js";
+import attachmentsRouter from "./routes/attachments.router.js";
 
-// The Express app is exported separately from app.listen() (see index.ts) so
-// Supertest can import `app` without opening a port. Do not merge these files.
 export const app = express();
 
 app.use(cors());
@@ -19,5 +18,6 @@ app.use("/api/categories", categoriesRouter);
 app.use("/api/requesters", requestersRouter);
 app.use("/api/related-systems", relatedSystemsRouter);
 app.use("/api/tickets", ticketsRouter);
+app.use("/api/attachments", attachmentsRouter);
 
 export default app;

--- a/server/src/controllers/attachments.controller.ts
+++ b/server/src/controllers/attachments.controller.ts
@@ -1,5 +1,4 @@
 import { Request, Response } from "express";
-import path from "path";
 import fs from "fs";
 import { getPrisma } from "../prisma.js";
 import {
@@ -8,8 +7,9 @@ import {
   MAX_ACTIVE_ATTACHMENTS,
 } from "../utils/attachmentValidation.js";
 
+// ── POST /api/tickets/:ticketNumber/attachments ────────────────────────────
+
 /**
- * POST /api/tickets/:ticketNumber/attachments
  * Uploads a file attachment to an existing Ticket.
  * Validates file type, size, and active attachment count.
  * If the ticket exists but upload validation fails, the ticket is NOT rolled back.
@@ -18,12 +18,9 @@ export const uploadAttachment = async (req: Request, res: Response): Promise<voi
   const prisma = getPrisma();
   const { ticketNumber } = req.params;
   const requesterId = Number(req.body.requesterId);
-
-  // multer v2 stores file in req.file
   const file = req.file as Express.Multer.File | undefined;
 
   if (!requesterId || isNaN(requesterId)) {
-    // Clean up uploaded file if it slipped through
     if (file?.path) fs.unlink(file.path, () => {});
     res.status(400).json({
       error: { code: "VALIDATION_ERROR", message: "requesterId is required." },
@@ -38,19 +35,14 @@ export const uploadAttachment = async (req: Request, res: Response): Promise<voi
     return;
   }
 
-  // Validate MIME type
   if (!isAllowedMimeType(file.mimetype)) {
     fs.unlink(file.path, () => {});
     res.status(415).json({
-      error: {
-        code: "UNSUPPORTED_MEDIA_TYPE",
-        message: "Only JPG, PNG, WEBP, and PDF files are allowed.",
-      },
+      error: { code: "UNSUPPORTED_MEDIA_TYPE", message: "Only JPG, PNG, WEBP, and PDF files are allowed." },
     });
     return;
   }
 
-  // Validate file size
   if (!isAllowedFileSize(file.size)) {
     fs.unlink(file.path, () => {});
     res.status(400).json({
@@ -60,7 +52,6 @@ export const uploadAttachment = async (req: Request, res: Response): Promise<voi
   }
 
   try {
-    // Verify ticket exists and belongs to the requester
     const ticket = await prisma.ticket.findUnique({ where: { ticketNumber } });
     if (!ticket) {
       fs.unlink(file.path, () => {});
@@ -69,13 +60,10 @@ export const uploadAttachment = async (req: Request, res: Response): Promise<voi
     }
     if (ticket.requesterId !== requesterId) {
       fs.unlink(file.path, () => {});
-      res.status(403).json({
-        error: { code: "FORBIDDEN", message: "You do not own this ticket." },
-      });
+      res.status(403).json({ error: { code: "FORBIDDEN", message: "You do not own this ticket." } });
       return;
     }
 
-    // Check active attachment count
     const activeCount = await prisma.attachment.count({
       where: { ticketId: ticket.id, removedAt: null },
     });
@@ -90,7 +78,6 @@ export const uploadAttachment = async (req: Request, res: Response): Promise<voi
       return;
     }
 
-    // Persist attachment metadata
     const attachment = await prisma.attachment.create({
       data: {
         ticketId:     ticket.id,
@@ -101,14 +88,13 @@ export const uploadAttachment = async (req: Request, res: Response): Promise<voi
       },
     });
 
-    // Return metadata only — never expose storedPath to the client
     res.status(201).json({
-      id:           attachment.id,
-      originalName: attachment.originalName,
-      mimeType:     attachment.mimeType,
-      sizeBytes:    attachment.sizeBytes,
-      uploadedAt:   attachment.uploadedAt,
-      removedAt:    attachment.removedAt,
+      id:            attachment.id,
+      originalName:  attachment.originalName,
+      mimeType:      attachment.mimeType,
+      sizeBytes:     attachment.sizeBytes,
+      uploadedAt:    attachment.uploadedAt,
+      removedAt:     attachment.removedAt,
       removalReason: attachment.removalReason,
     });
   } catch (err) {
@@ -116,6 +102,150 @@ export const uploadAttachment = async (req: Request, res: Response): Promise<voi
     if (file?.path) fs.unlink(file.path, () => {});
     res.status(500).json({
       error: { code: "SERVER_ERROR", message: "Unable to upload attachment. Please try again later." },
+    });
+  }
+};
+
+// ── GET /api/attachments/:id/download ─────────────────────────────────────
+
+/**
+ * Downloads the file for an active attachment.
+ * Returns 410 Gone if the attachment has been soft-removed.
+ * Returns 403 if the requesting Requester does not own the ticket.
+ */
+export const downloadAttachment = async (req: Request, res: Response): Promise<void> => {
+  const prisma = getPrisma();
+  const id = Number(req.params.id);
+  const requesterId = Number(req.query.requesterId);
+
+  if (!req.query.requesterId || isNaN(requesterId)) {
+    res.status(400).json({
+      error: { code: "VALIDATION_ERROR", message: "requesterId is required." },
+    });
+    return;
+  }
+
+  if (isNaN(id)) {
+    res.status(400).json({
+      error: { code: "VALIDATION_ERROR", message: "Invalid attachment id." },
+    });
+    return;
+  }
+
+  try {
+    const attachment = await prisma.attachment.findUnique({
+      where: { id },
+      include: { ticket: { select: { requesterId: true } } },
+    });
+
+    if (!attachment) {
+      res.status(404).json({ error: { code: "NOT_FOUND", message: "Attachment not found." } });
+      return;
+    }
+
+    if (attachment.ticket.requesterId !== requesterId) {
+      res.status(403).json({ error: { code: "FORBIDDEN", message: "You do not own this attachment." } });
+      return;
+    }
+
+    if (attachment.removedAt !== null) {
+      res.status(410).json({
+        error: { code: "GONE", message: "This attachment has been removed and is no longer available." },
+      });
+      return;
+    }
+
+    if (!fs.existsSync(attachment.storedPath)) {
+      res.status(404).json({ error: { code: "NOT_FOUND", message: "Attachment file not found on server." } });
+      return;
+    }
+
+    res.setHeader("Content-Type", attachment.mimeType);
+    res.setHeader(
+      "Content-Disposition",
+      `attachment; filename="${encodeURIComponent(attachment.originalName)}"`
+    );
+    fs.createReadStream(attachment.storedPath).pipe(res);
+  } catch (err) {
+    console.error("Failed to download attachment:", err);
+    res.status(500).json({
+      error: { code: "SERVER_ERROR", message: "Unable to download attachment. Please try again later." },
+    });
+  }
+};
+
+// ── PATCH /api/attachments/:id/remove ─────────────────────────────────────
+
+/**
+ * Soft-removes an attachment. Sets removedAt and removalReason.
+ * The file is no longer downloadable after removal.
+ * The metadata row is retained for audit purposes.
+ */
+export const removeAttachment = async (req: Request, res: Response): Promise<void> => {
+  const prisma = getPrisma();
+  const id = Number(req.params.id);
+  const requesterId = Number(req.body.requesterId);
+  const removalReason =
+    typeof req.body.removalReason === "string" ? req.body.removalReason.trim() : "";
+
+  if (!req.body.requesterId || isNaN(requesterId)) {
+    res.status(400).json({
+      error: { code: "VALIDATION_ERROR", message: "requesterId is required." },
+    });
+    return;
+  }
+
+  if (!removalReason || removalReason.length < 5) {
+    res.status(400).json({
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "A removal reason of at least 5 characters is required.",
+      },
+    });
+    return;
+  }
+
+  try {
+    const attachment = await prisma.attachment.findUnique({
+      where: { id },
+      include: { ticket: { select: { requesterId: true } } },
+    });
+
+    if (!attachment) {
+      res.status(404).json({ error: { code: "NOT_FOUND", message: "Attachment not found." } });
+      return;
+    }
+
+    if (attachment.ticket.requesterId !== requesterId) {
+      res.status(403).json({ error: { code: "FORBIDDEN", message: "You do not own this attachment." } });
+      return;
+    }
+
+    if (attachment.removedAt !== null) {
+      res.status(409).json({
+        error: { code: "ALREADY_REMOVED", message: "This attachment has already been removed." },
+      });
+      return;
+    }
+
+    const updated = await prisma.attachment.update({
+      where: { id },
+      data:  { removedAt: new Date(), removalReason },
+    });
+
+    res.status(200).json({
+      id:            updated.id,
+      originalName:  updated.originalName,
+      mimeType:      updated.mimeType,
+      sizeBytes:     updated.sizeBytes,
+      uploadedAt:    updated.uploadedAt,
+      removedAt:     updated.removedAt,
+      removalReason: updated.removalReason,
+    });
+  } catch (err) {
+    console.error("Failed to remove attachment:", err);
+    res.status(500).json({
+      error: { code: "SERVER_ERROR", message: "Unable to remove attachment. Please try again later." },
     });
   }
 };

--- a/server/src/routes/attachments.router.ts
+++ b/server/src/routes/attachments.router.ts
@@ -1,0 +1,15 @@
+import { Router } from "express";
+import {
+  downloadAttachment,
+  removeAttachment,
+} from "../controllers/attachments.controller.js";
+
+const router = Router();
+
+// GET  /api/attachments/:id/download — stream active file; 410 if soft-removed
+router.get("/:id/download", downloadAttachment);
+
+// PATCH /api/attachments/:id/remove — soft-remove with reason
+router.patch("/:id/remove", removeAttachment);
+
+export default router;

--- a/server/tests/lab-02/ticket-detail.api.test.ts
+++ b/server/tests/lab-02/ticket-detail.api.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import { app } from "../../src/app.js";
+
+// ── Shared mock data ──────────────────────────────────────────────────────
+
+const REQUESTER_A_ID = 1;
+const REQUESTER_B_ID = 2;
+
+const ACTIVE_ATTACHMENT = {
+  id:            1,
+  ticketId:      1,
+  originalName:  "screenshot.png",
+  storedPath:    "uploads/fake-path.png",
+  mimeType:      "image/png",
+  sizeBytes:     204800,
+  uploadedAt:    new Date().toISOString(),
+  removedAt:     null,
+  removalReason: null,
+  ticket:        { requesterId: REQUESTER_A_ID },
+};
+
+const REMOVED_ATTACHMENT = {
+  ...ACTIVE_ATTACHMENT,
+  id:            2,
+  removedAt:     new Date().toISOString(),
+  removalReason: "Not relevant",
+};
+
+const MOCK_TICKET = {
+  id:               1,
+  ticketNumber:     "TKT-2026-000001",
+  requesterId:      REQUESTER_A_ID,
+  categoryId:       1,
+  relatedSystemId:  1,
+  summary:          "Laptop battery drains quickly",
+  description:      "Description of the issue.",
+  requestedPriority: "MEDIUM",
+  status:           "NEW",
+  ticketDate:       new Date().toISOString(),
+  createdAt:        new Date().toISOString(),
+  updatedAt:        new Date().toISOString(),
+  requester:        { id: 1, name: "Jennifer Anderson" },
+  category:         { id: 1, name: "Hardware" },
+  relatedSystem:    { id: 1, name: "Corporate Laptop" },
+  attachments:      [ACTIVE_ATTACHMENT],
+};
+
+// ── Prisma mock ───────────────────────────────────────────────────────────
+
+const mockFindUniqueTicket     = vi.fn();
+const mockFindUniqueAttachment = vi.fn();
+const mockUpdateAttachment     = vi.fn();
+
+vi.mock("../../src/prisma.js", () => ({
+  getPrisma: () => ({
+    requesterUser: { findFirst: vi.fn().mockResolvedValue({ id: 1, isActive: true }) },
+    ticket: {
+      findUnique: mockFindUniqueTicket,
+      count:      vi.fn().mockResolvedValue(0),
+      findMany:   vi.fn().mockResolvedValue([]),
+      create:     vi.fn(),
+    },
+    attachment: {
+      findUnique: mockFindUniqueAttachment,
+      update:     mockUpdateAttachment,
+      count:      vi.fn().mockResolvedValue(0),
+      create:     vi.fn(),
+    },
+    category:      { findUnique: vi.fn() },
+    relatedSystem: { findFirst: vi.fn() },
+  }),
+}));
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe("GET /api/tickets/:ticketNumber", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindUniqueTicket.mockResolvedValue(MOCK_TICKET);
+  });
+
+  it("returns 200 with ticket and attachments array for the owning requester", async () => {
+    const res = await request(app)
+      .get(`/api/tickets/TKT-2026-000001?requesterId=${REQUESTER_A_ID}`);
+    expect(res.status).toBe(200);
+    expect(res.body.ticketNumber).toBe("TKT-2026-000001");
+    expect(Array.isArray(res.body.attachments)).toBe(true);
+  });
+
+  it("returns 403 when a different requester tries to access the ticket", async () => {
+    const res = await request(app)
+      .get(`/api/tickets/TKT-2026-000001?requesterId=${REQUESTER_B_ID}`);
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 404 when the ticket does not exist", async () => {
+    mockFindUniqueTicket.mockResolvedValue(null);
+    const res = await request(app)
+      .get(`/api/tickets/TKT-9999-999999?requesterId=${REQUESTER_A_ID}`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("PATCH /api/attachments/:id/remove", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindUniqueAttachment.mockResolvedValue(ACTIVE_ATTACHMENT);
+    mockUpdateAttachment.mockResolvedValue({
+      ...ACTIVE_ATTACHMENT,
+      removedAt:     new Date(),
+      removalReason: "Uploaded the wrong file",
+    });
+  });
+
+  it("returns 200 and sets removedAt when valid reason is provided by the owner", async () => {
+    const res = await request(app)
+      .patch("/api/attachments/1/remove")
+      .send({ requesterId: REQUESTER_A_ID, removalReason: "Uploaded the wrong file" });
+    expect(res.status).toBe(200);
+    expect(res.body.removedAt).toBeTruthy();
+    expect(res.body.removalReason).toBe("Uploaded the wrong file");
+  });
+
+  it("returns 400 when removalReason is missing", async () => {
+    const res = await request(app)
+      .patch("/api/attachments/1/remove")
+      .send({ requesterId: REQUESTER_A_ID });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 400 when removalReason is too short (< 5 chars)", async () => {
+    const res = await request(app)
+      .patch("/api/attachments/1/remove")
+      .send({ requesterId: REQUESTER_A_ID, removalReason: "nope" });
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 403 when a different requester tries to remove the attachment", async () => {
+    const res = await request(app)
+      .patch("/api/attachments/1/remove")
+      .send({ requesterId: REQUESTER_B_ID, removalReason: "Valid reason here" });
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 404 when the attachment does not exist", async () => {
+    mockFindUniqueAttachment.mockResolvedValue(null);
+    const res = await request(app)
+      .patch("/api/attachments/999/remove")
+      .send({ requesterId: REQUESTER_A_ID, removalReason: "Valid reason here" });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 409 when the attachment is already removed", async () => {
+    mockFindUniqueAttachment.mockResolvedValue(REMOVED_ATTACHMENT);
+    const res = await request(app)
+      .patch("/api/attachments/2/remove")
+      .send({ requesterId: REQUESTER_A_ID, removalReason: "Trying to remove again" });
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("ALREADY_REMOVED");
+  });
+});
+
+describe("GET /api/attachments/:id/download", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 403 when a different requester tries to download", async () => {
+    mockFindUniqueAttachment.mockResolvedValue(ACTIVE_ATTACHMENT);
+    const res = await request(app)
+      .get(`/api/attachments/1/download?requesterId=${REQUESTER_B_ID}`);
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 410 when the attachment has been soft-removed", async () => {
+    mockFindUniqueAttachment.mockResolvedValue(REMOVED_ATTACHMENT);
+    const res = await request(app)
+      .get(`/api/attachments/2/download?requesterId=${REQUESTER_A_ID}`);
+    expect(res.status).toBe(410);
+    expect(res.body.error.code).toBe("GONE");
+  });
+
+  it("returns 404 when the attachment does not exist", async () => {
+    mockFindUniqueAttachment.mockResolvedValue(null);
+    const res = await request(app)
+      .get(`/api/attachments/999/download?requesterId=${REQUESTER_A_ID}`);
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
Summary
- Adds a requester-facing Ticket Detail page and attachment lifecycle (upload, remove, download) to the ticket system.

Changes

Navigation
- Refactor `Page` type from a plain string union into a discriminated union: `{ name: "my_tickets" }`, `{ name: "create_ticket" }`, `{ name: "ticket_detail", ticketNumber: string }`
- Add `TicketDetail` component, wired up in `App.jsx` and rendered when `page.name === "ticket_detail"`
- Add `onOpenTicket` callback to `MyTickets`, so selecting a ticket navigates to its detail page with the ticket number

API (`api.ts`)
- Add `removeAttachment(attachmentId, requesterId, removeReason)` — calls `PATCH /api/attachments/:id/remove`; requires a `removeReason` of at least 8 characters (soft-delete, not a hard delete)
- Add `getAttachmentDownloadUrl(attachmentId, requesterId)` — returns the download URL for an active attachment; the backend returns 410 if the attachment has been soft-removed

Other
- Minor type/interface updates in `MyTickets.tsx` to support the new props